### PR TITLE
27.1 update firebase for ts v4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "nyc": "^15.1.0",
         "ts-mockito": "^2.6.1",
         "ts-node": "^10.2.1",
-        "typescript": "4.8"
+        "typescript": "^4.8.4"
       },
       "engines": {
         "node": "^16.17.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "nyc": "^15.1.0",
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.2.1",
-    "typescript": "^4.3.5"
+    "typescript": "^4.8.4"
   },
   "dependencies": {
     "@google-cloud/local-auth": "^2.1.0",

--- a/src/extensions/firebase-backup/firebase-extension.ts
+++ b/src/extensions/firebase-backup/firebase-extension.ts
@@ -1,7 +1,8 @@
 import { BaseServerExtension } from '../extension-interface';
 import { Firestore } from 'firebase-admin/firestore';
-import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { cert, getApps } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
+import firebaseAppAdmin from 'firebase-admin';
 import { AttendingServerV2 } from '../../attending-server/base-attending-server';
 import { QueueBackup, ServerBackup } from '../../models/backups';
 import { FgBlue, FgCyan, ResetColor } from '../../utils/command-line-colors';
@@ -20,13 +21,14 @@ class FirebaseServerBackupExtension extends BaseServerExtension {
         serverName: string,
         serverId: string
     ): Promise<FirebaseServerBackupExtension> {
+        let asdf: firebaseAppAdmin.app.App | undefined = undefined;; 
         if (getApps().length === 0) {
-            initializeApp({
+            asdf = firebaseAppAdmin.initializeApp({
                 credential: cert(environment.firebaseCredentials)
             });
         }
         const instance = new FirebaseServerBackupExtension(
-            getFirestore(),
+            getFirestore(asdf ?? undefined),
             serverId,
             serverName
         );

--- a/src/extensions/firebase-backup/firebase-extension.ts
+++ b/src/extensions/firebase-backup/firebase-extension.ts
@@ -21,14 +21,13 @@ class FirebaseServerBackupExtension extends BaseServerExtension {
         serverName: string,
         serverId: string
     ): Promise<FirebaseServerBackupExtension> {
-        let asdf: firebaseAppAdmin.app.App | undefined = undefined;; 
         if (getApps().length === 0) {
-            asdf = firebaseAppAdmin.initializeApp({
+            firebaseAppAdmin.initializeApp({
                 credential: cert(environment.firebaseCredentials)
             });
         }
         const instance = new FirebaseServerBackupExtension(
-            getFirestore(asdf ?? undefined),
+            getFirestore(),
             serverId,
             serverName
         );

--- a/src/extensions/session-calendar/calendar-states.ts
+++ b/src/extensions/session-calendar/calendar-states.ts
@@ -1,5 +1,5 @@
 import { Collection } from 'discord.js';
-import { initializeApp } from 'firebase-admin';
+import firebaseAppAdmin from 'firebase-admin';
 import { getApps, cert } from 'firebase-admin/app';
 import { Firestore, getFirestore } from 'firebase-admin/firestore';
 import { CalendarQueueExtension } from './calendar-queue-extension';
@@ -43,7 +43,7 @@ class CalendarExtensionState {
             return new CalendarExtensionState(serverId, serverName);
         }
         if (getApps().length === 0) {
-            initializeApp({
+            firebaseAppAdmin.initializeApp({
                 credential: cert(firebaseCredentials)
             });
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,7 +51,7 @@
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
     // "types": [],                                 /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */


### PR DESCRIPTION
discord.js v14 uses typescript v4.8, so to migrate to discord.js v14, we need to update typescript.

However, ts v4.8 has creates an issue with our current method of using firebase: 
https://github.com/firebase/firebase-admin-node/issues/593
Following the steps in the comments of this thread, the issue has been resolved

tl;dr fixed issue with connecting to firebase in typescript v4.8 