### PR TITLE
71 help menu fix

### DIFF
--- a/help-channel-messages/AdminCommands.ts
+++ b/help-channel-messages/AdminCommands.ts
@@ -339,7 +339,7 @@ const seriousModeHelp: HelpMessage = {
         value: 'serious_mode'
     },
     useInHelpChannel: true,
-    useInHelpCommand: false,
+    useInHelpCommand: true,
     message: {
         embeds: [
             {
@@ -374,7 +374,7 @@ const settingsHelp: HelpMessage = {
         value: 'settings'
     },
     useInHelpChannel: true,
-    useInHelpCommand: false,
+    useInHelpCommand: true,
     message: {
         embeds: [
             {
@@ -405,16 +405,16 @@ const settingsHelp: HelpMessage = {
 
 const setAutoGiveStudentRoleHelp: HelpMessage = {
     nameValuePair: {
-        name: 'set_auto_give_student_role',
-        value: 'set_auto_give_student_role'
+        name: 'auto_give_student_role',
+        value: 'auto_give_student_role'
     },
     useInHelpChannel: true,
-    useInHelpCommand: false,
+    useInHelpCommand: true,
     message: {
         embeds: [
             {
                 color: EmbedColor.NoColor,
-                title: 'Command: `/set_auto_give_student_role`',
+                title: 'Command: `/auto_give_student_role`',
                 fields: [
                     {
                         name: 'Description',
@@ -450,7 +450,6 @@ const adminCommandHelpMessages: HelpMessage[] = [
     stopLoggingHelp,
     setQueueAutoClearHelp,
     seriousModeHelp,
-    // ! Temporarily have useInHelpCommand=false since it causes the /help command to fail generation as it get too many fields
     settingsHelp,
     setAutoGiveStudentRoleHelp
 ];

--- a/help-channel-messages/HelperCommands.ts
+++ b/help-channel-messages/HelperCommands.ts
@@ -169,7 +169,7 @@ const clearHelp: HelpMessage = {
         value: 'clear'
     },
     useInHelpChannel: true,
-    useInHelpCommand: false,
+    useInHelpCommand: true,
     message: {
         embeds: [
             {
@@ -203,7 +203,7 @@ const pauseHelp: HelpMessage = {
         value: 'pause'
     },
     useInHelpChannel: true,
-    useInHelpCommand: false,
+    useInHelpCommand: true,
     message: {
         embeds: [
             {
@@ -237,7 +237,7 @@ const resumeHelp: HelpMessage = {
         value: 'resume'
     },
     useInHelpChannel: true,
-    useInHelpCommand: false,
+    useInHelpCommand: true,
     message: {
         embeds: [
             {

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -455,7 +455,8 @@ async function showAfterSessionMessageModal(
  * The `/help` command
  */
 async function help(interaction: ChatInputCommandInteraction<'cached'>): Promise<void> {
-    await interaction.editReply(HelpMenuEmbed(0));
+    const server = AttendingServerV2.get(interaction.guildId);
+    await interaction.editReply(HelpMenuEmbed(server, 0));
 }
 
 /**

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -11,9 +11,6 @@ import { CommandHandlerProps } from './handler-interface.js';
 import { AsciiTable3, AlignmentEnum } from 'ascii-table3';
 import { CommandNames } from './interaction-constants/interaction-names.js';
 import { ChatInputCommandInteraction } from 'discord.js';
-import { adminCommandHelpMessages } from '../../help-channel-messages/AdminCommands.js';
-import { helperCommandHelpMessages } from '../../help-channel-messages/HelperCommands.js';
-import { studentCommandHelpMessages } from '../../help-channel-messages/StudentCommands.js';
 import {
     updateCommandHelpChannels,
     createOfficeVoiceChannels
@@ -32,6 +29,7 @@ import {
     channelsAreUnderLimit
 } from './shared-validations.js';
 import { AttendingServerV2 } from '../attending-server/base-attending-server.js';
+import { HelpMenuEmbed } from './shared-interaciton-functions.js';
 
 const baseYabobCommandMap: CommandHandlerProps = {
     methodMap: {
@@ -454,22 +452,7 @@ async function showAfterSessionMessageModal(
  * The `/help` command
  */
 async function help(interaction: ChatInputCommandInteraction<'cached'>): Promise<void> {
-    const commandName = interaction.options.getString('command', true);
-    const helpMessage =
-        adminCommandHelpMessages.find(
-            message => message.nameValuePair.name === commandName
-        ) ??
-        helperCommandHelpMessages.find(
-            message => message.nameValuePair.name === commandName
-        ) ??
-        studentCommandHelpMessages.find(
-            message => message.nameValuePair.name === commandName
-        );
-    if (helpMessage !== undefined) {
-        await interaction.editReply(helpMessage.message);
-    } else {
-        throw new CommandParseError('Command not found.');
-    }
+    await interaction.editReply(HelpMenuEmbed(0));
 }
 
 /**

--- a/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
+++ b/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
@@ -13,9 +13,6 @@ import { Routes } from 'discord-api-types/v9';
 import { ChannelType, Guild } from 'discord.js';
 import { magenta, red } from '../../utils/command-line-colors.js';
 import { environment } from '../../environment/environment-manager.js';
-import { adminCommandHelpMessages } from '../../../help-channel-messages/AdminCommands.js';
-import { helperCommandHelpMessages } from '../../../help-channel-messages/HelperCommands.js';
-import { studentCommandHelpMessages } from '../../../help-channel-messages/StudentCommands.js';
 import { CommandNames } from './interaction-names.js';
 import { CommandData } from '../../utils/type-aliases.js';
 
@@ -313,25 +310,7 @@ const promptHelpTopicCommand = new SlashCommandBuilder()
 function generateHelpCommand() {
     return new SlashCommandBuilder()
         .setName(CommandNames.help)
-        .setDescription('Get help with the bot')
-        .addStringOption(option =>
-            option
-                .setName('command')
-                .setDescription('The command to get help with')
-                .setRequired(true)
-                .addChoices(
-                    // TODO: Use autocomplete to dynamically generate choices here
-                    ...adminCommandHelpMessages
-                        .filter(helpMessage => helpMessage.useInHelpCommand)
-                        .map(helpMessage => helpMessage.nameValuePair),
-                    ...helperCommandHelpMessages
-                        .filter(helpMessage => helpMessage.useInHelpCommand)
-                        .map(helpMessage => helpMessage.nameValuePair),
-                    ...studentCommandHelpMessages
-                        .filter(helpMessage => helpMessage.useInHelpCommand)
-                        .map(helpMessage => helpMessage.nameValuePair)
-                )
-        );
+        .setDescription('Get help with the bot');
 }
 
 /** The raw data that can be sent to Discord */

--- a/src/interaction-handling/interaction-constants/interaction-names.ts
+++ b/src/interaction-handling/interaction-constants/interaction-names.ts
@@ -58,7 +58,10 @@ enum ButtonNames {
     PromptHelpTopicConfig1 = 'PromptHelpTopicConfig1',
     PromptHelpTopicConfig2 = 'PromptHelpTopicConfig2',
     SeriousModeConfig1 = 'SeriousModeConfig1',
-    SeriousModeConfig2 = 'SeriousModeConfig2'
+    SeriousModeConfig2 = 'SeriousModeConfig2',
+    HelpMenuLeft = 'HelpMenuLeft',
+    HelpMenuRight = 'HelpMenuRight',
+    ReturnToHelpMenu = 'ReturnToHelpMenu'
 }
 
 /**
@@ -75,7 +78,8 @@ enum ModalNames {
 /** Known base yabob select menu names */
 enum SelectMenuNames {
     ServerSettings = 'ServerSettings',
-    SelectLoggingChannel = 'SelectLoggingChannel'
+    SelectLoggingChannel = 'SelectLoggingChannel',
+    HelpMenu = 'HelpMenu'
 }
 
 export { CommandNames, ButtonNames, ModalNames, SelectMenuNames };

--- a/src/interaction-handling/shared-interaciton-functions.ts
+++ b/src/interaction-handling/shared-interaciton-functions.ts
@@ -1,31 +1,98 @@
-import { ActionRowBuilder, SelectMenuBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
-import { adminCommandHelpMessages } from "../../help-channel-messages/AdminCommands.js";
-import { helperCommandHelpMessages } from "../../help-channel-messages/HelperCommands.js";
-import { studentCommandHelpMessages } from "../../help-channel-messages/StudentCommands.js";
-import { buildComponent, UnknownId } from "../utils/component-id-factory.js";
-import { SimpleEmbed, EmbedColor } from "../utils/embed-helper.js";
-import { YabobEmbed } from "../utils/type-aliases.js";
+import {
+    ActionRowBuilder,
+    SelectMenuBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    EmbedBuilder
+} from 'discord.js';
+import { adminCommandHelpMessages } from '../../help-channel-messages/AdminCommands.js';
+import { helperCommandHelpMessages } from '../../help-channel-messages/HelperCommands.js';
+import { studentCommandHelpMessages } from '../../help-channel-messages/StudentCommands.js';
+import { buildComponent, UnknownId } from '../utils/component-id-factory.js';
+import { EmbedColor } from '../utils/embed-helper.js';
+import { YabobEmbed } from '../utils/type-aliases.js';
+import {
+    ButtonNames,
+    SelectMenuNames
+} from './interaction-constants/interaction-names.js';
+import { AttendingServerV2 } from '../attending-server/base-attending-server.js';
 
 /**
  * Composes the help embed
  * @param page The page number of the help menu. 0 is home page
  */
-function HelpMenuEmbed(page: number): YabobEmbed {
-
+function HelpMenuEmbed(server: AttendingServerV2, page: number): YabobEmbed {
     // get all the help messages
-    const allHelpMessages = adminCommandHelpMessages.concat(
-        helperCommandHelpMessages.concat(studentCommandHelpMessages)
-    );
-
-    // get upto 25 help messages starting from page * 25
-    const pageHelpMessages = allHelpMessages.slice(page * 25, (page + 1) * 25);
+    //TODO: create file with help message utils
+    const allHelpMessages = adminCommandHelpMessages
+        .concat(helperCommandHelpMessages.concat(studentCommandHelpMessages))
+        .filter(helpMessage => helpMessage.useInHelpCommand === true);
 
     // create select menu from the help messages
+    const selectMenu = HelpMenuSelectMenu(server, page);
+
+    // create left and right buttons
+
+    const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        buildComponent(new ButtonBuilder(), [
+            'other',
+            ButtonNames.HelpMenuLeft,
+            server.guild.id,
+            UnknownId
+        ])
+            .setStyle(ButtonStyle.Primary)
+            .setLabel('Previvous Page')
+            .setEmoji('⬅️')
+            .setDisabled(page === 0),
+        buildComponent(new ButtonBuilder(), [
+            'other',
+            ButtonNames.HelpMenuRight,
+            server.guild.id,
+            UnknownId
+        ])
+            .setStyle(ButtonStyle.Primary)
+            .setLabel('Nect Page')
+            .setEmoji('➡️')
+            .setDisabled(page === Math.floor(allHelpMessages.length / 25))
+    );
+
+    const embed = new EmbedBuilder()
+        .setTitle('Help Menu')
+        .setColor(EmbedColor.Pink)
+        .setDescription(
+            'This is the help menu for YABOB. Use the buttons below to navigate through the menu.'
+        )
+        .setFooter({
+            text: `Page ${page + 1}/${Math.ceil(allHelpMessages.length / 25)}`
+        });
+
+    return {
+        embeds: [embed],
+        components: [buttons, selectMenu]
+    };
+}
+
+/**
+ * Creates the select menu for the help menu
+ * @param server 
+ * @param page 
+ * @returns 
+ */
+function HelpMenuSelectMenu(
+    server: AttendingServerV2,
+    page: number
+): ActionRowBuilder<SelectMenuBuilder> {
+    const allHelpMessages = adminCommandHelpMessages
+        .concat(helperCommandHelpMessages.concat(studentCommandHelpMessages))
+        .filter(helpMessage => helpMessage.useInHelpCommand === true);
+
+    const pageHelpMessages = allHelpMessages.slice(page * 25, (page + 1) * 25);
+
     const selectMenu = new ActionRowBuilder<SelectMenuBuilder>().addComponents(
         buildComponent(new SelectMenuBuilder(), [
             'other',
-            'help-menu-select-' + page,
-            UnknownId,
+            SelectMenuNames.HelpMenu,
+            server.guild.id,
             UnknownId
         ]).addOptions(
             pageHelpMessages.map(helpMessage => {
@@ -38,37 +105,30 @@ function HelpMenuEmbed(page: number): YabobEmbed {
         )
     );
 
-    // create left and right buttons
-
-    const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
-        buildComponent(new ButtonBuilder(), [
-            'other',
-            'help-menu-left-' + page,
-            UnknownId,
-            UnknownId
-        ]).setStyle(ButtonStyle.Primary)
-            .setLabel('Left')
-            .setDisabled(page === 0),
-        buildComponent(new ButtonBuilder(), [
-            'other',
-            'help-menu-right-' + page,
-            UnknownId,
-            UnknownId
-        ]).setStyle(ButtonStyle.Primary)
-            .setLabel('Right')
-            .setDisabled(page === Math.floor(allHelpMessages.length / 25))
-    );
-
-    return {
-        embeds: SimpleEmbed(
-            'Help Menu',
-            EmbedColor.Pink,
-            'This is the help menu for YABOB. Use the buttons below to navigate through the menu.'
-        ).embeds,
-        components: [buttons, selectMenu]
-    };
+    return selectMenu;
 }
 
-export {
-    HelpMenuEmbed
-};
+/**
+ * Creates the return to help menu button
+ * @param server 
+ * @returns 
+ */
+function ReturnToHelpMenuButton(
+    server: AttendingServerV2
+): ActionRowBuilder<ButtonBuilder> {
+    const button = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        buildComponent(new ButtonBuilder(), [
+            'other',
+            ButtonNames.ReturnToHelpMenu,
+            server.guild.id,
+            UnknownId
+        ])
+            .setStyle(ButtonStyle.Primary)
+            .setLabel('Return to Main Menu')
+            .setEmoji('🏠')
+    );
+
+    return button;
+}
+
+export { HelpMenuEmbed, HelpMenuSelectMenu, ReturnToHelpMenuButton };

--- a/src/interaction-handling/shared-interaciton-functions.ts
+++ b/src/interaction-handling/shared-interaciton-functions.ts
@@ -1,0 +1,74 @@
+import { ActionRowBuilder, SelectMenuBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
+import { adminCommandHelpMessages } from "../../help-channel-messages/AdminCommands.js";
+import { helperCommandHelpMessages } from "../../help-channel-messages/HelperCommands.js";
+import { studentCommandHelpMessages } from "../../help-channel-messages/StudentCommands.js";
+import { buildComponent, UnknownId } from "../utils/component-id-factory.js";
+import { SimpleEmbed, EmbedColor } from "../utils/embed-helper.js";
+import { YabobEmbed } from "../utils/type-aliases.js";
+
+/**
+ * Composes the help embed
+ * @param page The page number of the help menu. 0 is home page
+ */
+function HelpMenuEmbed(page: number): YabobEmbed {
+
+    // get all the help messages
+    const allHelpMessages = adminCommandHelpMessages.concat(
+        helperCommandHelpMessages.concat(studentCommandHelpMessages)
+    );
+
+    // get upto 25 help messages starting from page * 25
+    const pageHelpMessages = allHelpMessages.slice(page * 25, (page + 1) * 25);
+
+    // create select menu from the help messages
+    const selectMenu = new ActionRowBuilder<SelectMenuBuilder>().addComponents(
+        buildComponent(new SelectMenuBuilder(), [
+            'other',
+            'help-menu-select-' + page,
+            UnknownId,
+            UnknownId
+        ]).addOptions(
+            pageHelpMessages.map(helpMessage => {
+                return {
+                    label: helpMessage.nameValuePair.name,
+                    value: helpMessage.nameValuePair.value,
+                    default: false
+                };
+            })
+        )
+    );
+
+    // create left and right buttons
+
+    const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        buildComponent(new ButtonBuilder(), [
+            'other',
+            'help-menu-left-' + page,
+            UnknownId,
+            UnknownId
+        ]).setStyle(ButtonStyle.Primary)
+            .setLabel('Left')
+            .setDisabled(page === 0),
+        buildComponent(new ButtonBuilder(), [
+            'other',
+            'help-menu-right-' + page,
+            UnknownId,
+            UnknownId
+        ]).setStyle(ButtonStyle.Primary)
+            .setLabel('Right')
+            .setDisabled(page === Math.floor(allHelpMessages.length / 25))
+    );
+
+    return {
+        embeds: SimpleEmbed(
+            'Help Menu',
+            EmbedColor.Pink,
+            'This is the help menu for YABOB. Use the buttons below to navigate through the menu.'
+        ).embeds,
+        components: [buttons, selectMenu]
+    };
+}
+
+export {
+    HelpMenuEmbed
+};

--- a/src/utils/embed-helper.ts
+++ b/src/utils/embed-helper.ts
@@ -7,11 +7,11 @@ import {
     TextBasedChannel,
     User,
     ApplicationCommandOptionType,
-    EmbedBuilder
-} from 'discord.js';
+    EmbedBuilder} from 'discord.js';
 import { CommandParseError, QueueError, ServerError } from '../utils/error-types.js';
 import { client } from '../global-states.js';
 import { OptionalRoleId, SpecialRoleValues } from './type-aliases.js';
+
 
 type ExpectedError = QueueError | ServerError | CommandParseError;
 
@@ -25,7 +25,7 @@ enum EmbedColor {
     UnexpectedError = 0xff0000, // pure red
     Neutral = 0xffffff, // White
     Yellow = 0xffd866, // Yellow
-    NoColor = 0x2f3137, // the embed background
+    NoColor = 0x2f3137, // the embed background (dark mode)
     Aqua = 0x78dce8,
     DiscordPurple = 0x5865f2,
     PastelPurple = 0x738adb, // old discord purple
@@ -655,5 +655,5 @@ export {
     SlashCommandLogEmbed,
     SlashCommandLogEmbed2,
     SelectMenuLogEmbed,
-    SelectMenuLogEmbed2
+    SelectMenuLogEmbed2,
 };


### PR DESCRIPTION
Stuff done:
- help menu, buttons to switch pages, return to main menu button

To do: 
- Add emojis to help message structure to use with select menu (more fancy!)

Ideas:
- Main menu will have 3 buttons, each will redirect to a submenu for Admin, Helper and Student commands respectively