### PR TITLE
4.3.x Resolving Minor issues

### DIFF
--- a/help-channel-messages/AdminCommands.ts
+++ b/help-channel-messages/AdminCommands.ts
@@ -438,6 +438,75 @@ const setAutoGiveStudentRoleHelp: HelpMessage = {
     }
 };
 
+const createOfficesHelp: HelpMessage = {
+    nameValuePair: {
+        name: 'create_offices',
+        value: 'create_offices'
+    },
+    useInHelpChannel: true,
+    useInHelpCommand: false,
+    message: {
+        embeds: [
+            {
+                color: EmbedColor.NoColor,
+                title: 'Command: `/create_offices`',
+                fields: [
+                    {
+                        name: 'Description',
+                        value: 'Creates the office hours channels for the server. This command will create \
+                        the voice channels and set the appropriate permissions.',
+                        inline: false
+                    },
+                    {
+                        name: 'Options',
+                        value: '`category_name: string` The name of the category to create the voice channels in. \n\
+                        `office_names: string` The name of the voice channels to create. Will be created as office_name-1, office_name-2 etc. \n\
+                        `number_of_offices: number` The number of offices to create.',
+                        inline: true
+                    },
+                    {
+                        name: 'Example Usage',
+                        value: '`/create_offices "Office Hours" "Office" 3`',
+                        inline: true
+                    }
+                ]
+            }
+        ]
+    }
+};
+
+const setRoleHelp: HelpMessage = {
+    nameValuePair: {
+        name: 'set_role',
+        value: 'set_role'
+    },
+    useInHelpChannel: true,
+    useInHelpCommand: false,
+    message: {
+        embeds: [
+            {
+                color: EmbedColor.NoColor,
+                title: 'Command: `/set_role`',
+                fields: [
+                    {
+                        name: 'Description',
+                        value: 'Sets the role(s) for the server to use for `Bot Admin`, `Helper` and `Student` roles.'
+                    },
+                    {
+                        name: 'Options',
+                        value: '`role_name: [Bot Admin | Staff | Studnet]`: The name of the role to set. \n\
+                        `role: Role`: The role to set the chosen role to.'
+                    },
+                    {
+                        name: 'Example Usage',
+                        value: '`/set_role Bot Admin @Moderator`'
+                    }
+                ]
+            }
+        ]
+    }
+};
+
 const adminCommandHelpMessages: HelpMessage[] = [
     adminCommandsTitleMessage,
     queueAddHelp,
@@ -452,7 +521,9 @@ const adminCommandHelpMessages: HelpMessage[] = [
     seriousModeHelp,
     // ! Temporarily have useInHelpCommand=false since it causes the /help command to fail generation as it get too many fields
     settingsHelp,
-    setAutoGiveStudentRoleHelp
+    setAutoGiveStudentRoleHelp,
+    createOfficesHelp,
+    setRoleHelp
 ];
 
 export { adminCommandHelpMessages };

--- a/help-channel-messages/AdminCommands.ts
+++ b/help-channel-messages/AdminCommands.ts
@@ -233,7 +233,7 @@ const setAfterSessionsMsgHelp: HelpMessage = {
             }
         ]
     },
-    emoji: '📝'
+    emoji: '📨'
 };
 
 const setLoggingChannelHelp: HelpMessage = {
@@ -456,7 +456,7 @@ const createOfficesHelp: HelpMessage = {
         value: 'create_offices'
     },
     useInHelpChannel: true,
-    useInHelpCommand: false,
+    useInHelpCommand: true,
     message: {
         embeds: [
             {
@@ -484,7 +484,8 @@ const createOfficesHelp: HelpMessage = {
                 ]
             }
         ]
-    }
+    },
+    emoji: '🔊'
 };
 
 const setRoleHelp: HelpMessage = {
@@ -493,7 +494,7 @@ const setRoleHelp: HelpMessage = {
         value: 'set_role'
     },
     useInHelpChannel: true,
-    useInHelpCommand: false,
+    useInHelpCommand: true,
     message: {
         embeds: [
             {
@@ -516,7 +517,8 @@ const setRoleHelp: HelpMessage = {
                 ]
             }
         ]
-    }
+    },
+    emoji: '👥'
 };
 
 const adminCommandHelpMessages: HelpMessage[] = [

--- a/help-channel-messages/AdminCommands.ts
+++ b/help-channel-messages/AdminCommands.ts
@@ -200,42 +200,6 @@ const clearAllHelp: HelpMessage = {
     emoji: '🧹'
 };
 
-const setAfterSessionsMsgHelp: HelpMessage = {
-    nameValuePair: {
-        name: 'set_after_session_msg',
-        value: 'set_after_session_msg'
-    },
-    useInHelpChannel: true,
-    useInHelpCommand: true,
-    message: {
-        embeds: [
-            {
-                color: EmbedColor.NoColor,
-                title: 'Command: `/set_after_session_msg [message]`',
-                fields: [
-                    {
-                        name: 'Description',
-                        value: 'Prompts a modal (aka form) where you can enter a message \
-                        that is to be sent to the students after a session is over.',
-                        inline: false
-                    },
-                    {
-                        name: 'Modal Input Fields',
-                        value: '`message: text - paragraph`\nThe message to send to the queue when a session ends.',
-                        inline: true
-                    },
-                    {
-                        name: 'Example Usage',
-                        value: '`/set_after_session_msg`',
-                        inline: true
-                    }
-                ]
-            }
-        ]
-    },
-    emoji: '📨'
-};
-
 const setLoggingChannelHelp: HelpMessage = {
     nameValuePair: {
         name: 'set_logging_channel',
@@ -306,78 +270,6 @@ const stopLoggingHelp: HelpMessage = {
     emoji: '🪵'
 };
 
-const setQueueAutoClearHelp: HelpMessage = {
-    nameValuePair: {
-        name: 'set_queue_auto_clear',
-        value: 'set_queue_auto_clear'
-    },
-    useInHelpChannel: true,
-    useInHelpCommand: true,
-    message: {
-        embeds: [
-            {
-                color: EmbedColor.NoColor,
-                title: 'Command: `/set_queue_auto_clear`',
-                fields: [
-                    {
-                        name: 'Description',
-                        value: 'Sets the time after which the queue will be cleared automatically.',
-                        inline: false
-                    },
-                    {
-                        name: 'Modal Input Fields',
-                        value: '`hours: number - 2 digit max` \n`minutes: number - 2 digit max`\
-                        \nSubmitting the modal will set the auto clear time to hours:minutes',
-                        inline: true
-                    },
-                    {
-                        name: 'Example Usage',
-                        value: '`/set_queue_auto_clear`',
-                        inline: true
-                    }
-                ]
-            }
-        ]
-    },
-    emoji: '🕐'
-};
-
-const seriousModeHelp: HelpMessage = {
-    nameValuePair: {
-        name: 'serious_mode',
-        value: 'serious_mode'
-    },
-    useInHelpChannel: true,
-    useInHelpCommand: true,
-    message: {
-        embeds: [
-            {
-                color: EmbedColor.NoColor,
-                title: 'Command: `/serious_mode`',
-                fields: [
-                    {
-                        name: 'Description',
-                        value: 'Toggles serious mode. When serious mode is on, the bot will not use \
-                        emotes or emoticons in messages and embeds.',
-                        inline: false
-                    },
-                    {
-                        name: 'Options',
-                        value: 'None',
-                        inline: true
-                    },
-                    {
-                        name: 'Example Usage',
-                        value: '`/serious_mode`',
-                        inline: true
-                    }
-                ]
-            }
-        ]
-    },
-    emoji: '🧐'
-};
-
 const settingsHelp: HelpMessage = {
     nameValuePair: {
         name: 'settings',
@@ -399,7 +291,7 @@ const settingsHelp: HelpMessage = {
                     },
                     {
                         name: 'Options',
-                        value: 'None',
+                        value: '`sub_menu_jump: string`: Jump to a specific sub menu.',
                         inline: true
                     },
                     {
@@ -412,42 +304,6 @@ const settingsHelp: HelpMessage = {
         ]
     },
     emoji: '⚙️'
-};
-
-const setAutoGiveStudentRoleHelp: HelpMessage = {
-    nameValuePair: {
-        name: 'auto_give_student_role',
-        value: 'auto_give_student_role'
-    },
-    useInHelpChannel: true,
-    useInHelpCommand: true,
-    message: {
-        embeds: [
-            {
-                color: EmbedColor.NoColor,
-                title: 'Command: `/auto_give_student_role`',
-                fields: [
-                    {
-                        name: 'Description',
-                        value: 'Toggles whether or not the bot will automatically give the student role \
-                        to users who join the server.',
-                        inline: false
-                    },
-                    {
-                        name: 'Options',
-                        value: 'None',
-                        inline: true
-                    },
-                    {
-                        name: 'Example Usage',
-                        value: '`/set_auto_give_student_role`',
-                        inline: true
-                    }
-                ]
-            }
-        ]
-    },
-    emoji: '👨‍🎓'
 };
 
 const createOfficesHelp: HelpMessage = {
@@ -528,13 +384,9 @@ const adminCommandHelpMessages: HelpMessage[] = [
     cleanupQueueHelp,
     cleanupHelpChannelHelp,
     clearAllHelp,
-    setAfterSessionsMsgHelp,
     setLoggingChannelHelp,
     stopLoggingHelp,
-    setQueueAutoClearHelp,
-    seriousModeHelp,
     settingsHelp,
-    setAutoGiveStudentRoleHelp,
     createOfficesHelp,
     setRoleHelp
 ];

--- a/help-channel-messages/StudentCommands.ts
+++ b/help-channel-messages/StudentCommands.ts
@@ -162,7 +162,8 @@ const queueNotifyHelp: HelpMessage = {
                 ]
             }
         ]
-    }
+    },
+    emoji: '🔔'
 };
 
 const helpHelp: HelpMessage = {

--- a/help-channel-messages/StudentCommands.ts
+++ b/help-channel-messages/StudentCommands.ts
@@ -97,7 +97,7 @@ const leaveHelp: HelpMessage = {
 const listHelpersHelp: HelpMessage = {
     nameValuePair: {
         name: 'list_helpers',
-        value: 'list helpers'
+        value: 'list_helpers'
     },
     useInHelpChannel: true,
     useInHelpCommand: true,
@@ -120,6 +120,40 @@ const listHelpersHelp: HelpMessage = {
                     {
                         name: 'Example Usage',
                         value: '`/list_helpers`',
+                        inline: true
+                    }
+                ]
+            }
+        ]
+    }
+};
+
+const queueNotifyHelp: HelpMessage = {
+    nameValuePair: {
+        name: 'queue_notify',
+        value: 'queue_notify'
+    },
+    useInHelpChannel: true,
+    useInHelpCommand: true,
+    message: {
+        embeds: [
+            {
+                color: EmbedColor.NoColor,
+                title: 'Command: `/queue_notify [queue_name] [on|off]]`',
+                fields: [
+                    {
+                        name: 'Description',
+                        value: 'Toggles whether the sender will be notified when they are next in line for the queue `queue_name`',
+                        inline: false
+                    },
+                    {
+                        name: 'Options',
+                        value: '`queue_name: string`\nName of the queue to toggle the notification for\n\n`on|off: string`\nWhether to turn the notification on or off',
+                        inline: true
+                    },
+                    {
+                        name: 'Example Usage',
+                        value: '`/queue_notify ECS32A`',
                         inline: true
                     }
                 ]
@@ -168,6 +202,7 @@ const studentCommandHelpMessages: HelpMessage[] = [
     enqueueHelp,
     leaveHelp,
     listHelpersHelp,
+    queueNotifyHelp,
     helpHelp
 ];
 

--- a/src/attending-server/firebase-backup.ts
+++ b/src/attending-server/firebase-backup.ts
@@ -230,4 +230,10 @@ function useQueueBackup(
     return descriptor;
 }
 
-export { loadExternalServerData, useSettingsBackup, useQueueBackup, useFullBackup, backupQueueData };
+export {
+    loadExternalServerData,
+    useSettingsBackup,
+    useQueueBackup,
+    useFullBackup,
+    backupQueueData
+};

--- a/src/attending-server/server-settings-menus.ts
+++ b/src/attending-server/server-settings-menus.ts
@@ -790,6 +790,9 @@ function SeriousModeConfigMenu(
     isDm: boolean,
     updateMessage = ''
 ): YabobEmbed {
+
+    const noQueues = server.queues.length === 0;
+
     const embed = new EmbedBuilder()
         .setTitle(`🧐 Serious Mode Configuration for ${server.guild.name} 🧐`)
         .setColor(EmbedColor.Aqua)
@@ -805,9 +808,10 @@ function SeriousModeConfigMenu(
             },
             {
                 name: 'Current Configuration',
-                value: server.isSerious
+                value: (server.isSerious
                     ? `**Enabled** - YABOB will not use emojis or emoticons for fun purposes.`
-                    : `**Disabled** - YABOB can use emojis and emoticons for fun purposes.`
+                    : `**Disabled** - YABOB can use emojis and emoticons for fun purposes.`) +
+                    `\n\n**Note:** ${noQueues ? 'There are no queues in the server so serious mode doesn\'t have any noticable effect' : `Serious mode affects all queues in this server.`}`
             }
         );
     if (updateMessage.length > 0) {

--- a/src/attending-server/server-settings-menus.ts
+++ b/src/attending-server/server-settings-menus.ts
@@ -3,7 +3,7 @@ import {
     ButtonBuilder,
     ButtonStyle,
     EmbedBuilder,
-    SelectMenuBuilder,
+    StringSelectMenuBuilder,
     Snowflake
 } from 'discord.js';
 import { EmbedColor } from '../utils/embed-helper.js';
@@ -30,9 +30,9 @@ import {
  */
 function SettingsSwitcher(
     currentMenu: SettingsMenuConstructor
-): ActionRowBuilder<SelectMenuBuilder> {
-    return new ActionRowBuilder<SelectMenuBuilder>().addComponents(
-        buildComponent(new SelectMenuBuilder(), [
+): ActionRowBuilder<StringSelectMenuBuilder> {
+    return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        buildComponent(new StringSelectMenuBuilder(), [
             'other',
             SelectMenuNames.ServerSettings,
             UnknownId,
@@ -624,23 +624,24 @@ function LoggingChannelConfigMenu(
                 longestCommonSubsequence(channel2.name.toLowerCase(), 'logs') -
                 longestCommonSubsequence(channel1.name.toLowerCase(), 'logs')
         );
-    const channelsSelectMenu = new ActionRowBuilder<SelectMenuBuilder>().addComponents(
-        buildComponent(new SelectMenuBuilder(), [
-            'other',
-            SelectMenuNames.SelectLoggingChannel,
-            server.guild.id,
-            channelId
-        ])
-            .setPlaceholder('Select a Text Channel')
-            .addOptions(
-                // Cannot have more than 25 options
-                mostLikelyLoggingChannels.first(25).map(channel => ({
-                    label: channel.name,
-                    description: channel.name,
-                    value: channel.id
-                }))
-            )
-    );
+    const channelsSelectMenu =
+        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+            buildComponent(new StringSelectMenuBuilder(), [
+                'other',
+                SelectMenuNames.SelectLoggingChannel,
+                server.guild.id,
+                channelId
+            ])
+                .setPlaceholder('Select a Text Channel')
+                .addOptions(
+                    // Cannot have more than 25 options
+                    mostLikelyLoggingChannels.first(25).map(channel => ({
+                        label: channel.name,
+                        description: channel.name,
+                        value: channel.id
+                    }))
+                )
+        );
     return {
         embeds: [embed.data],
         components: [

--- a/src/attending-server/server-settings-menus.ts
+++ b/src/attending-server/server-settings-menus.ts
@@ -42,7 +42,7 @@ function SettingsSwitcher(
             .addOptions(
                 serverSettingsMainMenuOptions
                     .filter(menuOption => menuOption.menu !== currentMenu)
-                    .map(option => option.optionData)
+                    .map(option => option.selectMenuOptionData)
             )
     );
 }
@@ -84,75 +84,83 @@ const documentationLinks = {
  */
 const serverSettingsMainMenuOptions: SettingsMenuOption[] = [
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '🏠',
             label: 'Main Menu',
             description: 'Return to the main menu',
             value: 'main-menu'
         },
+        useInSettingsCommand: false,
         menu: SettingsMainMenu
     },
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '📝',
             label: 'Server Roles',
             description: 'Configure the server roles',
             value: 'server-roles'
         },
+        useInSettingsCommand: true,
         menu: RolesConfigMenuInGuild
     },
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '📨',
             label: 'After Session Message',
             description: 'Configure the message sent after a session',
             value: 'after-session-message'
         },
+        useInSettingsCommand: true,
         menu: AfterSessionMessageConfigMenu
     },
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '⏳',
             label: 'Queue Auto Clear',
             description: 'Configure the auto-clearing of queues',
             value: 'queue-auto-clear'
         },
+        useInSettingsCommand: true,
         menu: QueueAutoClearConfigMenu
     },
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '🪵',
             label: 'Logging Channel',
             description: 'Configure the logging channel',
             value: 'logging-channel'
         },
+        useInSettingsCommand: true,
         menu: LoggingChannelConfigMenu
     },
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '🎓',
             label: 'Auto Give Student Role',
             description: 'Configure the auto-giving of the student role',
             value: 'auto-give-student-role'
         },
+        useInSettingsCommand: true,
         menu: AutoGiveStudentRoleConfigMenu
     },
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '🙋',
             label: 'Help Topic Prompt',
             description: 'Configure the help topic prompt',
             value: 'help-topic-prompt'
         },
+        useInSettingsCommand: true,
         menu: PromptHelpTopicConfigMenu
     },
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '🧐',
             label: 'Serious Mode',
             description: 'Configure the serious mode',
             value: 'serious-mode'
         },
+        useInSettingsCommand: true,
         menu: SeriousModeConfigMenu
     }
 ];

--- a/src/attending-server/server-settings-menus.ts
+++ b/src/attending-server/server-settings-menus.ts
@@ -790,7 +790,6 @@ function SeriousModeConfigMenu(
     isDm: boolean,
     updateMessage = ''
 ): YabobEmbed {
-
     const noQueues = server.queues.length === 0;
 
     const embed = new EmbedBuilder()
@@ -808,10 +807,15 @@ function SeriousModeConfigMenu(
             },
             {
                 name: 'Current Configuration',
-                value: (server.isSerious
-                    ? `**Enabled** - YABOB will not use emojis or emoticons for fun purposes.`
-                    : `**Disabled** - YABOB can use emojis and emoticons for fun purposes.`) +
-                    `\n\n**Note:** ${noQueues ? 'There are no queues in the server so serious mode doesn\'t have any noticable effect' : `Serious mode affects all queues in this server.`}`
+                value:
+                    (server.isSerious
+                        ? `**Enabled** - YABOB will not use emojis or emoticons for fun purposes.`
+                        : `**Disabled** - YABOB can use emojis and emoticons for fun purposes.`) +
+                    `\n\n**Note:** ${
+                        noQueues
+                            ? "There are no queues in the server so serious mode doesn't have any noticable effect"
+                            : `Serious mode affects all queues in this server.`
+                    }`
             }
         );
     if (updateMessage.length > 0) {

--- a/src/attending-server/server-settings-menus.ts
+++ b/src/attending-server/server-settings-menus.ts
@@ -179,9 +179,7 @@ const serverSettingsMenuOptions: SettingsMenuOption[] = [
  * @param isDm is it in dm?
  * @returns the setting menu embed object
  */
-function SettingsMainMenu(
-    server: AttendingServerV2
-): YabobEmbed {
+function SettingsMainMenu(server: AttendingServerV2): YabobEmbed {
     const embed = new EmbedBuilder()
         .setTitle(`🛠 Server Settings for ${server.guild.name} 🛠`)
         .setColor(EmbedColor.Aqua)

--- a/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-interaction-names.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-interaction-names.ts
@@ -1,6 +1,16 @@
-enum GoogleSheetCommands {
+enum GoogleSheetCommandNames {
     stats = 'stats',
     weekly_report = 'weekly_report'
 }
 
-export { GoogleSheetCommands };
+enum GoogleSheetButtonNames {
+    ResetGoogleSheetSettings = 'ResetGoogleSheetSettings',
+    ShowGoogleSheetSettingsModal = 'ShowGoogleSheetsSettingsModal'
+}
+
+enum GoogleSheetModalNames {
+    GoogleSheetSettingsModal = 'GoogleSheetsSettingsModal',
+    GoogleSheetSettingsModalMenuVersion = 'GoogleSheetsSettingsModalMenuVersion'
+}
+
+export { GoogleSheetCommandNames, GoogleSheetButtonNames, GoogleSheetModalNames };

--- a/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-interaction-names.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-interaction-names.ts
@@ -1,7 +1,6 @@
 enum GoogleSheetCommands {
     stats = 'stats',
-    weekly_report = 'weekly_report',
-    set_google_sheet = 'set_google_sheet'
+    weekly_report = 'weekly_report'
 }
 
 export { GoogleSheetCommands };

--- a/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-modal-objects.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-modal-objects.ts
@@ -1,0 +1,44 @@
+import {
+    ActionRowBuilder,
+    ModalActionRowComponentBuilder,
+    ModalBuilder,
+    Snowflake,
+    TextInputBuilder,
+    TextInputStyle
+} from 'discord.js';
+import { buildComponent, UnknownId } from '../../../utils/component-id-factory.js';
+import { GoogleSheetExtensionState } from '../google-sheet-states.js';
+import { GoogleSheetModalNames } from './google-sheet-interaction-names.js';
+
+/**
+ * Sets the Google Sheet URL for the server
+ * @param serverId
+ * @param useMenu if true, then modal submit returns the menu embed, else returns the success embed
+ * @returns
+ */
+function googleSheetSettingsModal(serverId: Snowflake, useMenu = false): ModalBuilder {
+    const state = GoogleSheetExtensionState.allStates.get(serverId);
+    const modal = buildComponent(new ModalBuilder(), [
+        'other',
+        useMenu
+            ? GoogleSheetModalNames.GoogleSheetSettingsModalMenuVersion
+            : GoogleSheetModalNames.GoogleSheetSettingsModal,
+        serverId,
+        UnknownId
+    ])
+        .setTitle('Google Sheet Logging Settings')
+        .setComponents(
+            new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(
+                new TextInputBuilder()
+                    .setCustomId('google_sheet_id')
+                    .setLabel('Google Sheet ID')
+                    .setPlaceholder('Enter Google Sheet ID')
+                    .setStyle(TextInputStyle.Paragraph)
+                    .setRequired(true)
+                    .setValue(state?.googleSheet.spreadsheetId ?? '')
+            )
+        );
+    return modal;
+}
+
+export { googleSheetSettingsModal };

--- a/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-settings-menu.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-settings-menu.ts
@@ -1,9 +1,11 @@
-import { EmbedBuilder } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } from 'discord.js';
 import { EmbedColor } from '../../../utils/embed-helper.js';
 import { SettingsMenuOption, YabobEmbed } from '../../../utils/type-aliases.js';
 import { FrozenServer } from '../../extension-utils.js';
 import { GoogleSheetExtensionState } from '../google-sheet-states.js';
 import { SettingsSwitcher } from '../../../attending-server/server-settings-menus.js';
+import { buildComponent } from '../../../utils/component-id-factory.js';
+import { GoogleSheetButtonNames } from './google-sheet-interaction-names.js';
 
 /**
  * Options for the server settings main menu
@@ -62,9 +64,30 @@ function GoogleSheetSettingsConfigMenu(
     if (updateMessage.length > 0) {
         embed.setFooter({ text: `✅ ${updateMessage}` });
     }
+
+    const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        buildComponent(new ButtonBuilder(), [
+            isDm ? 'dm' : 'other',
+            GoogleSheetButtonNames.ShowGoogleSheetSettingsModal,
+            server.guild.id,
+            channelId
+        ])
+            .setEmoji('📊')
+            .setLabel('Change Google Sheet')
+            .setStyle(ButtonStyle.Secondary),
+        buildComponent(new ButtonBuilder(), [
+            isDm ? 'dm' : 'other',
+            GoogleSheetButtonNames.ResetGoogleSheetSettings,
+            server.guild.id,
+            channelId
+        ])
+            .setEmoji('🔗')
+            .setLabel('Reset Google Sheet')
+            .setStyle(ButtonStyle.Secondary)
+    );
     return {
         embeds: [embed],
-        components: [SettingsSwitcher(GoogleSheetSettingsConfigMenu)]
+        components: [buttons, SettingsSwitcher(GoogleSheetSettingsConfigMenu)]
     };
 }
 

--- a/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-settings-menu.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-settings-menu.ts
@@ -11,12 +11,13 @@ import { SettingsSwitcher } from '../../../attending-server/server-settings-menu
  */
 const googleSheetSettingsMainMenuOptions: SettingsMenuOption[] = [
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '📊',
             label: 'Google Sheet Logging Settings',
             description: 'Configure the Google Sheet Logging settings',
             value: 'google-sheet-settings'
         },
+        useInSettingsCommand: true,
         menu: GoogleSheetSettingsConfigMenu
     }
 ];

--- a/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-slash-commands.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-slash-commands.ts
@@ -3,7 +3,7 @@ import { GoogleSheetCommands } from './google-sheet-interaction-names.js';
 
 // `/get_statistics`
 const getStatistics = new SlashCommandBuilder()
-    .setName('stats')
+    .setName(GoogleSheetCommands.stats)
     .setDescription('Statistics')
     .addSubcommand(subcommand =>
         subcommand
@@ -64,7 +64,7 @@ const getStatistics = new SlashCommandBuilder()
 
 // `/weekly_report`
 const weeklyReport = new SlashCommandBuilder()
-    .setName('weekly_report')
+    .setName(GoogleSheetCommands.weekly_report)
     .setDescription('Get a weekly report for the past `x` weeks.')
     .addSubcommand(subcommand =>
         subcommand
@@ -95,25 +95,25 @@ const weeklyReport = new SlashCommandBuilder()
             )
     );
 
-// `/set_google_sheet`
-const setGoogleSheet = new SlashCommandBuilder()
-    .setName(GoogleSheetCommands.set_google_sheet)
-    .setDescription(
-        'Changes which google sheet to use when logging attendance statistics.'
-    )
-    .addStringOption(option =>
-        option
-            .setName('sheet_id')
-            .setDescription(
-                'The id of the new google sheet. See the user manual for how to find this id.'
-            )
-            .setRequired(true)
-    );
+// // `/set_google_sheet`
+// const setGoogleSheet = new SlashCommandBuilder()
+//     .setName(GoogleSheetCommands.set_google_sheet)
+//     .setDescription(
+//         'Changes which google sheet to use when logging attendance statistics.'
+//     )
+//     .addStringOption(option =>
+//         option
+//             .setName('sheet_id')
+//             .setDescription(
+//                 'The id of the new google sheet. See the user manual for how to find this id.'
+//             )
+//             .setRequired(true)
+//     );
 
 const googleSheetsCommands = [
     getStatistics.toJSON(),
-    weeklyReport.toJSON(),
-    setGoogleSheet.toJSON()
+    weeklyReport.toJSON()
+    // setGoogleSheet.toJSON()
 ];
 
 export { googleSheetsCommands };

--- a/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-slash-commands.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-slash-commands.ts
@@ -1,9 +1,9 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { GoogleSheetCommands } from './google-sheet-interaction-names.js';
+import { GoogleSheetCommandNames } from './google-sheet-interaction-names.js';
 
 // `/get_statistics`
 const getStatistics = new SlashCommandBuilder()
-    .setName(GoogleSheetCommands.stats)
+    .setName(GoogleSheetCommandNames.stats)
     .setDescription('Statistics')
     .addSubcommand(subcommand =>
         subcommand
@@ -64,7 +64,7 @@ const getStatistics = new SlashCommandBuilder()
 
 // `/weekly_report`
 const weeklyReport = new SlashCommandBuilder()
-    .setName(GoogleSheetCommands.weekly_report)
+    .setName(GoogleSheetCommandNames.weekly_report)
     .setDescription('Get a weekly report for the past `x` weeks.')
     .addSubcommand(subcommand =>
         subcommand

--- a/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-slash-commands.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-constants/google-sheet-slash-commands.ts
@@ -95,25 +95,6 @@ const weeklyReport = new SlashCommandBuilder()
             )
     );
 
-// // `/set_google_sheet`
-// const setGoogleSheet = new SlashCommandBuilder()
-//     .setName(GoogleSheetCommands.set_google_sheet)
-//     .setDescription(
-//         'Changes which google sheet to use when logging attendance statistics.'
-//     )
-//     .addStringOption(option =>
-//         option
-//             .setName('sheet_id')
-//             .setDescription(
-//                 'The id of the new google sheet. See the user manual for how to find this id.'
-//             )
-//             .setRequired(true)
-//     );
-
-const googleSheetsCommands = [
-    getStatistics.toJSON(),
-    weeklyReport.toJSON()
-    // setGoogleSheet.toJSON()
-];
+const googleSheetsCommands = [getStatistics.toJSON(), weeklyReport.toJSON()];
 
 export { googleSheetsCommands };

--- a/src/extensions/google-sheet-logging/google-sheet-interaction-extension.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-interaction-extension.ts
@@ -11,7 +11,9 @@ import {
 } from './google-sheet-constants/GoogleSheetCommands.js';
 import { googleSheetSettingsMainMenuOptions } from './google-sheet-constants/google-sheet-settings-menu.js';
 import { googleSheetsCommands } from './google-sheet-constants/google-sheet-slash-commands.js';
+import { googleSheetButtonMap } from './interaction-handling/button-handler.js';
 import { googleSheetCommandMap } from './interaction-handling/command-handler.js';
+import { googleSheetModalMap } from './interaction-handling/modal-handler.js';
 import { loadSheetById } from './shared-sheet-functions.js';
 
 class GoogleSheetInteractionExtension
@@ -27,6 +29,16 @@ class GoogleSheetInteractionExtension
         staff: googleSheetStaffHelpMessages,
         student: []
     };
+
+    override buttonMap = googleSheetButtonMap;
+
+    override modalMap = googleSheetModalMap;
+
+    override slashCommandData = googleSheetsCommands;
+
+    override commandMap = googleSheetCommandMap;
+
+    override settingsMainMenuOptions = googleSheetSettingsMainMenuOptions;
 
     /**
      * Checks if the default google sheet is accessible
@@ -55,12 +67,6 @@ class GoogleSheetInteractionExtension
             )} as the default google sheet.`
         );
     }
-
-    override slashCommandData = googleSheetsCommands;
-
-    override commandMap = googleSheetCommandMap;
-
-    override settingsMainMenuOptions = googleSheetSettingsMainMenuOptions;
 }
 
 export { GoogleSheetInteractionExtension };

--- a/src/extensions/google-sheet-logging/interaction-handling/button-handler.ts
+++ b/src/extensions/google-sheet-logging/interaction-handling/button-handler.ts
@@ -1,0 +1,61 @@
+import { ButtonInteraction } from 'discord.js';
+import { AttendingServerV2 } from '../../../attending-server/base-attending-server.js';
+import { environment } from '../../../environment/environment-manager.js';
+import { ButtonHandlerProps } from '../../../interaction-handling/handler-interface.js';
+import { GoogleSheetButtonNames } from '../google-sheet-constants/google-sheet-interaction-names.js';
+import { GoogleSheetExtensionState } from '../google-sheet-states.js';
+import { googleSheetSettingsModal } from '../google-sheet-constants/google-sheet-modal-objects.js';
+import { GoogleSheetSettingsConfigMenu } from '../google-sheet-constants/google-sheet-settings-menu.js';
+import { GoogleSheetSuccessMessages } from '../google-sheet-constants/sheet-success-messages.js';
+
+const googleSheetButtonMap: ButtonHandlerProps = {
+    guildMethodMap: {
+        queue: {},
+        other: {
+            [GoogleSheetButtonNames.ResetGoogleSheetSettings]: resetGoogleSheetSettings,
+            [GoogleSheetButtonNames.ShowGoogleSheetSettingsModal]:
+                showGoogleSheetSettingsModal
+        }
+    },
+    dmMethodMap: {},
+    skipProgressMessageButtons: new Set([
+        GoogleSheetButtonNames.ResetGoogleSheetSettings,
+        GoogleSheetButtonNames.ShowGoogleSheetSettingsModal
+    ])
+};
+
+/**
+ * Resets the google sheets settings to the default specified in the environment
+ * @param interaction
+ */
+async function resetGoogleSheetSettings(
+    interaction: ButtonInteraction<'cached'>
+): Promise<void> {
+    const server = AttendingServerV2.get(interaction.guildId);
+    const state = GoogleSheetExtensionState.get(interaction.guildId);
+    await Promise.all([
+        state.setGoogleSheet(environment.sessionCalendar.YABOB_DEFAULT_CALENDAR_ID),
+        server.sendLogMessage(GoogleSheetSuccessMessages.updatedGoogleSheet(state.googleSheetURL))
+    ]);
+    await interaction.update(
+        GoogleSheetSettingsConfigMenu(
+            server,
+            interaction.channelId,
+            false,
+            'Successfully reset all calendar settings.'
+        )
+    );
+}
+
+/**
+ * Shows the modal for the google sheet settings
+ * @param interaction
+ */
+async function showGoogleSheetSettingsModal(
+    interaction: ButtonInteraction<'cached'>
+): Promise<void> {
+    const server = AttendingServerV2.get(interaction.guildId);
+    await interaction.showModal(googleSheetSettingsModal(server.guild.id, true));
+}
+
+export { googleSheetButtonMap };

--- a/src/extensions/google-sheet-logging/interaction-handling/command-handler.ts
+++ b/src/extensions/google-sheet-logging/interaction-handling/command-handler.ts
@@ -3,7 +3,6 @@ import { CommandHandlerProps } from '../../../interaction-handling/handler-inter
 import { SimpleEmbed, EmbedColor } from '../../../utils/embed-helper.js';
 import { Optional } from '../../../utils/type-aliases.js';
 import { GoogleSheetCommands } from '../google-sheet-constants/google-sheet-interaction-names.js';
-import { GoogleSheetSuccessMessages } from '../google-sheet-constants/sheet-success-messages.js';
 import { ExpectedSheetErrors } from '../google-sheet-constants/expected-sheet-errors.js';
 import { AttendingServerV2 } from '../../../attending-server/base-attending-server.js';
 import { GoogleSheetExtensionState } from '../google-sheet-states.js';
@@ -11,8 +10,7 @@ import { GoogleSheetExtensionState } from '../google-sheet-states.js';
 const googleSheetCommandMap: CommandHandlerProps = {
     methodMap: {
         [GoogleSheetCommands.stats]: getStatistics,
-        [GoogleSheetCommands.weekly_report]: getWeeklyReport,
-        [GoogleSheetCommands.set_google_sheet]: setGoogleSheet
+        [GoogleSheetCommands.weekly_report]: getWeeklyReport
     },
     skipProgressMessageCommands: new Set()
 };
@@ -433,20 +431,6 @@ async function getWeeklyReport(
             EmbedColor.Neutral,
             weeklyStatsString
         )
-    );
-}
-
-/**
- * Changes which google sheet to read from. The `/set_google_sheet` command
- */
-async function setGoogleSheet(
-    interaction: ChatInputCommandInteraction<'cached'>
-): Promise<void> {
-    const state = GoogleSheetExtensionState.get(interaction.guildId);
-    const sheetId = interaction.options.getString('sheet_id', true).trim();
-    await state.setGoogleSheet(sheetId);
-    await interaction.editReply(
-        GoogleSheetSuccessMessages.updatedGoogleSheet(state.googleSheet.title)
     );
 }
 

--- a/src/extensions/google-sheet-logging/interaction-handling/command-handler.ts
+++ b/src/extensions/google-sheet-logging/interaction-handling/command-handler.ts
@@ -2,15 +2,15 @@ import { ChatInputCommandInteraction, User } from 'discord.js';
 import { CommandHandlerProps } from '../../../interaction-handling/handler-interface.js';
 import { SimpleEmbed, EmbedColor } from '../../../utils/embed-helper.js';
 import { Optional } from '../../../utils/type-aliases.js';
-import { GoogleSheetCommands } from '../google-sheet-constants/google-sheet-interaction-names.js';
+import { GoogleSheetCommandNames } from '../google-sheet-constants/google-sheet-interaction-names.js';
 import { ExpectedSheetErrors } from '../google-sheet-constants/expected-sheet-errors.js';
 import { AttendingServerV2 } from '../../../attending-server/base-attending-server.js';
 import { GoogleSheetExtensionState } from '../google-sheet-states.js';
 
 const googleSheetCommandMap: CommandHandlerProps = {
     methodMap: {
-        [GoogleSheetCommands.stats]: getStatistics,
-        [GoogleSheetCommands.weekly_report]: getWeeklyReport
+        [GoogleSheetCommandNames.stats]: getStatistics,
+        [GoogleSheetCommandNames.weekly_report]: getWeeklyReport
     },
     skipProgressMessageCommands: new Set()
 };

--- a/src/extensions/google-sheet-logging/interaction-handling/modal-handler.ts
+++ b/src/extensions/google-sheet-logging/interaction-handling/modal-handler.ts
@@ -1,0 +1,57 @@
+import { ModalSubmitInteraction } from 'discord.js';
+import { ModalSubmitHandlerProps } from '../../../interaction-handling/handler-interface.js';
+import { GoogleSheetModalNames } from '../google-sheet-constants/google-sheet-interaction-names.js';
+import { AttendingServerV2 } from '../../../attending-server/base-attending-server.js';
+import { GoogleSheetExtensionState } from '../google-sheet-states.js';
+import { GoogleSheetSuccessMessages } from '../google-sheet-constants/sheet-success-messages.js';
+import { GoogleSheetSettingsConfigMenu } from '../google-sheet-constants/google-sheet-settings-menu.js';
+
+const googleSheetModalMap: ModalSubmitHandlerProps = {
+    guildMethodMap: {
+        queue: {},
+        other: {
+            [GoogleSheetModalNames.GoogleSheetSettingsModal]: interaction =>
+                updateGoogleSheetSettings(interaction, false),
+            [GoogleSheetModalNames.GoogleSheetSettingsModalMenuVersion]: interaction =>
+                updateGoogleSheetSettings(interaction, true)
+        }
+    },
+    dmMethodMap: {}
+};
+
+/**
+ * Updates the google sheet settings
+ * @param interaction
+ * @param useMenu
+ */
+async function updateGoogleSheetSettings(
+    interaction: ModalSubmitInteraction<'cached'>,
+    useMenu: boolean
+): Promise<void> {
+    const server = AttendingServerV2.get(interaction.guildId);
+    const state = GoogleSheetExtensionState.get(interaction.guildId);
+    const googleSheetID = interaction.fields.getTextInputValue('google_sheet_id');
+    await state.setGoogleSheet(googleSheetID);
+
+    server.sendLogMessage(
+        GoogleSheetSuccessMessages.updatedGoogleSheet(state.googleSheet.title)
+    );
+
+    if (useMenu && interaction.isFromMessage()) {
+        await interaction.update(
+            GoogleSheetSettingsConfigMenu(
+                server,
+                interaction.channelId,
+                false,
+                'Google Sheet settings have been saved!'
+            )
+        );
+    } else {
+        await interaction.reply({
+            ...GoogleSheetSuccessMessages.updatedGoogleSheet(state.googleSheet.title),
+            ephemeral: true
+        });
+    }
+}
+
+export { googleSheetModalMap };

--- a/src/extensions/session-calendar/calendar-constants/CalendarCommands.ts
+++ b/src/extensions/session-calendar/calendar-constants/CalendarCommands.ts
@@ -2,73 +2,6 @@
 import { EmbedColor } from '../../../utils/embed-helper.js';
 import { HelpMessage } from '../../../utils/type-aliases.js';
 
-const setCalendarHelp: HelpMessage = {
-    nameValuePair: {
-        name: 'set_calendar',
-        value: 'set_calendar'
-    },
-    useInHelpChannel: true,
-    useInHelpCommand: true,
-    message: {
-        embeds: [
-            {
-                color: EmbedColor.NoColor,
-                title: 'Command: `/set_calendar [calendar_id]`',
-                fields: [
-                    {
-                        name: 'Description',
-                        value: 'Prompts a modal to set the calendar for the server.',
-                        inline: false
-                    },
-                    {
-                        name: 'Options',
-                        value: "`calendar_id: string`\nID of the calendar to set.\
-                        \nGo to that particular calendar's Settings and Sharing tab. Scrolling down will take you do the Integrate Calendar Section. \
-                        Copy the Calendar ID. It should end with calendar.google.com.",
-                        inline: true
-                    },
-                    {
-                        name: 'Example Usage',
-                        value: '`/set_calendar 3o2ih5bk35b154@calendar.google.com`',
-                        inline: true
-                    }
-                ]
-            }
-        ]
-    },
-    emoji: '📅'
-};
-
-const unsetCalendarHelp: HelpMessage = {
-    nameValuePair: {
-        name: 'unset_calendar',
-        value: 'unset_calendar'
-    },
-    useInHelpChannel: true,
-    useInHelpCommand: true,
-    message: {
-        embeds: [
-            {
-                color: EmbedColor.NoColor,
-                title: 'Command: `/unset_calendar`',
-                fields: [
-                    {
-                        name: 'Description',
-                        value: 'Resets the calendar that YABOB reads from to the default calendar.',
-                        inline: false
-                    },
-                    {
-                        name: 'Example Usage',
-                        value: '`/unset_calendar`',
-                        inline: true
-                    }
-                ]
-            }
-        ]
-    },
-    emoji: '📅'
-};
-
 const makeCalendarStringHelp: HelpMessage = {
     nameValuePair: {
         name: 'make_calendar_string',
@@ -144,42 +77,6 @@ const makeCalendarStringAllHelp: HelpMessage = {
     emoji: '📅'
 };
 
-const setPublicEmbedUrlHelp: HelpMessage = {
-    nameValuePair: {
-        name: 'set_public_embed_url',
-        value: 'set_public_embed_url'
-    },
-    useInHelpChannel: true,
-    useInHelpCommand: true,
-    message: {
-        embeds: [
-            {
-                color: EmbedColor.NoColor,
-                title: 'Command: `/set_public_embed_url [url]`',
-                fields: [
-                    {
-                        name: 'Description',
-                        value: 'Sets the URL that upcoming sessions embed calendar redirects you to.',
-                        inline: false
-                    },
-                    {
-                        name: 'Options',
-                        value: '`url: string`\nA public url to a website which shows the calendar for the server.\
-                        \nThis url will be used in the queue embeds to redirect users to the calendar.',
-                        inline: true
-                    },
-                    {
-                        name: 'Example Usage',
-                        value: '`/set_public_embed_url https://supercoolcalendar.com`',
-                        inline: true
-                    }
-                ]
-            }
-        ]
-    },
-    emoji: '📅'
-};
-
 const whenNextHelp: HelpMessage = {
     nameValuePair: {
         name: 'when_next',
@@ -217,12 +114,6 @@ const whenNextHelp: HelpMessage = {
     emoji: '📅'
 };
 
-const calendarAdminHelpMessages = [
-    setCalendarHelp,
-    unsetCalendarHelp,
-    setPublicEmbedUrlHelp
-] as const;
-
 const calendarHelperHelpMessages = [
     makeCalendarStringHelp,
     makeCalendarStringAllHelp
@@ -230,8 +121,4 @@ const calendarHelperHelpMessages = [
 
 const calendarStudentHelpMessages = [whenNextHelp] as const;
 
-export {
-    calendarAdminHelpMessages,
-    calendarHelperHelpMessages,
-    calendarStudentHelpMessages
-};
+export { calendarHelperHelpMessages, calendarStudentHelpMessages };

--- a/src/extensions/session-calendar/calendar-constants/calendar-interaction-names.ts
+++ b/src/extensions/session-calendar/calendar-constants/calendar-interaction-names.ts
@@ -5,12 +5,12 @@
  */
 
 enum CalendarCommandNames {
-    set_calendar = 'set_calendar',
-    unset_calendar = 'unset_calendar',
+    // set_calendar = 'set_calendar',
+    // unset_calendar = 'unset_calendar',
     when_next = 'when_next',
     make_calendar_string = 'make_calendar_string',
-    make_calendar_string_all = 'make_calendar_string_all',
-    set_public_embed_url = 'set_public_embed_url'
+    make_calendar_string_all = 'make_calendar_string_all'
+    // set_public_embed_url = 'set_public_embed_url'
 }
 
 enum CalendarButtonNames {

--- a/src/extensions/session-calendar/calendar-constants/calendar-interaction-names.ts
+++ b/src/extensions/session-calendar/calendar-constants/calendar-interaction-names.ts
@@ -5,12 +5,9 @@
  */
 
 enum CalendarCommandNames {
-    // set_calendar = 'set_calendar',
-    // unset_calendar = 'unset_calendar',
     when_next = 'when_next',
     make_calendar_string = 'make_calendar_string',
     make_calendar_string_all = 'make_calendar_string_all'
-    // set_public_embed_url = 'set_public_embed_url'
 }
 
 enum CalendarButtonNames {

--- a/src/extensions/session-calendar/calendar-constants/calendar-settings-menu.ts
+++ b/src/extensions/session-calendar/calendar-constants/calendar-settings-menu.ts
@@ -14,12 +14,13 @@ import { CalendarButtonNames } from './calendar-interaction-names.js';
  */
 const calendarSettingsMainMenuOptions: SettingsMenuOption[] = [
     {
-        optionData: {
+        selectMenuOptionData: {
             emoji: '🗓',
             label: 'Calendar Settings',
             description: 'Configure the calendar settings',
             value: 'calendar-settings'
         },
+        useInSettingsCommand: true,
         menu: CalendarSettingsConfigMenu
     }
 ];

--- a/src/extensions/session-calendar/calendar-constants/calendar-slash-commands.ts
+++ b/src/extensions/session-calendar/calendar-constants/calendar-slash-commands.ts
@@ -4,26 +4,6 @@ import { SlashCommandBuilder } from '@discordjs/builders';
 import { ChannelType } from 'discord.js';
 import { CalendarCommandNames } from './calendar-interaction-names.js';
 
-// /set_calendar [calendar_id]
-const setCalendar = new SlashCommandBuilder()
-    .setName(CalendarCommandNames.set_calendar)
-    .setDescription(
-        'Commands to modify the resources connected to the /when_next command'
-    )
-    .addStringOption(option =>
-        option
-            .setName('calendar_id')
-            .setDescription('The link to the calendar')
-            .setRequired(true)
-    );
-
-// /unset_calendar
-const unsetCalendar = new SlashCommandBuilder()
-    .setName(CalendarCommandNames.unset_calendar)
-    .setDescription(
-        'De-syncs the bot from the current calendar and sets it to the default calendar'
-    );
-
 // /when_next [queue_name]
 const whenNext = new SlashCommandBuilder()
     .setName(CalendarCommandNames.when_next)
@@ -99,33 +79,10 @@ const makeCalendarStringAll = new SlashCommandBuilder()
             .setRequired(false)
     );
 
-// /set_public_embed_url [url] (enable)
-const setPublicEmbedUrl = new SlashCommandBuilder()
-    .setName(CalendarCommandNames.set_public_embed_url)
-    .setDescription('Use another public calendar embed')
-    .addStringOption(option =>
-        option
-            .setName('url')
-            .setDescription('The full URL to the public calendar embed')
-            .setRequired(true)
-    )
-    .addBooleanOption(option =>
-        option
-            .setName('enable')
-            .setDescription(
-                'Whether to switch to this new public url. ' +
-                    'If false, the value in `url` will be ignored'
-            )
-            .setRequired(true)
-    );
-
 const calendarCommands = [
-    setCalendar.toJSON(),
-    unsetCalendar.toJSON(),
     whenNext.toJSON(),
     makeCalendarStringCommand.toJSON(),
-    makeCalendarStringAll.toJSON(),
-    setPublicEmbedUrl.toJSON()
+    makeCalendarStringAll.toJSON()
 ];
 
 export { calendarCommands };

--- a/src/extensions/session-calendar/calendar-interaction-extension.ts
+++ b/src/extensions/session-calendar/calendar-interaction-extension.ts
@@ -4,7 +4,6 @@ import { calendarButtonMap } from './interaction-handling/button-handler.js';
 import { calendarCommandMap } from './interaction-handling/command-handler.js';
 import { calendarModalMap } from './interaction-handling/modal-handler.js';
 import {
-    calendarAdminHelpMessages,
     calendarHelperHelpMessages,
     calendarStudentHelpMessages
 } from './calendar-constants/CalendarCommands.js';
@@ -21,7 +20,7 @@ class SessionCalendarInteractionExtension extends BaseInteractionExtension {
     override commandMap = calendarCommandMap;
 
     override helpMessages = {
-        botAdmin: calendarAdminHelpMessages,
+        botAdmin: [],
         staff: calendarHelperHelpMessages,
         student: calendarStudentHelpMessages
     };

--- a/src/extensions/session-calendar/interaction-handling/button-handler.ts
+++ b/src/extensions/session-calendar/interaction-handling/button-handler.ts
@@ -26,6 +26,10 @@ const calendarButtonMap: ButtonHandlerProps = {
     ])
 };
 
+/**
+ * Resets the calendar settings to the default specified in the environment
+ * @param interaction
+ */
 async function resetCalendarSettings(
     interaction: ButtonInteraction<'cached'>
 ): Promise<void> {

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -16,15 +16,8 @@ import {
     createOfficeVoiceChannels
 } from '../attending-server/guild-actions.js';
 import { SettingsMainMenu } from '../attending-server/server-settings-menus.js';
-import {
-    ExpectedParseErrors,
-    ExpectedParseWarnings
-} from './interaction-constants/expected-interaction-errors.js';
-import {
-    AfterSessionMessageModal,
-    PromptHelpTopicModal,
-    QueueAutoClearModal
-} from './interaction-constants/modal-objects.js';
+import { ExpectedParseErrors } from './interaction-constants/expected-interaction-errors.js';
+import { PromptHelpTopicModal } from './interaction-constants/modal-objects.js';
 import { SuccessMessages } from './interaction-constants/success-messages.js';
 import {
     hasValidQueueArgument,
@@ -53,22 +46,13 @@ const baseYabobCommandMap: CommandHandlerProps = {
         [CommandNames.cleanup_help_channels]: cleanupHelpChannel,
         [CommandNames.help]: help,
         [CommandNames.set_logging_channel]: setLoggingChannel,
-        [CommandNames.set_queue_auto_clear]: showQueueAutoClearModal,
         [CommandNames.stop_logging]: stopLogging,
-        [CommandNames.serious_mode]: setSeriousMode,
         [CommandNames.create_offices]: createOffices,
         [CommandNames.set_roles]: setRoles,
         [CommandNames.settings]: settingsMenu,
-        [CommandNames.auto_give_student_role]: setAutoGiveStudentRole,
-        [CommandNames.set_after_session_msg]: showAfterSessionMessageModal,
-        [CommandNames.prompt_help_topic]: setPromptHelpTopic,
         [CommandNames.queue_notify]: joinQueueNotify
     },
-    skipProgressMessageCommands: new Set([
-        CommandNames.set_after_session_msg,
-        CommandNames.set_queue_auto_clear,
-        CommandNames.enqueue
-    ])
+    skipProgressMessageCommands: new Set([CommandNames.enqueue])
 };
 
 /**
@@ -440,22 +424,6 @@ async function cleanupHelpChannel(
 }
 
 /**
- * The `/set_after_session_msg` command
- */
-async function showAfterSessionMessageModal(
-    interaction: ChatInputCommandInteraction<'cached'>
-): Promise<void> {
-    const server = AttendingServerV2.get(interaction.guildId);
-    isTriggeredByMemberWithRoles(
-        server,
-        interaction.member,
-        CommandNames.set_after_session_msg,
-        'botAdmin'
-    );
-    await interaction.showModal(AfterSessionMessageModal(server.guild.id));
-}
-
-/**
  * The `/help` command
  */
 async function help(interaction: ChatInputCommandInteraction<'cached'>): Promise<void> {
@@ -492,22 +460,6 @@ async function setLoggingChannel(
 }
 
 /**
- * The `/set_queue_auto_clear` command
- */
-async function showQueueAutoClearModal(
-    interaction: ChatInputCommandInteraction<'cached'>
-): Promise<void> {
-    const server = AttendingServerV2.get(interaction.guildId);
-    isTriggeredByMemberWithRoles(
-        server,
-        interaction.member,
-        CommandNames.set_queue_auto_clear,
-        'botAdmin'
-    );
-    await interaction.showModal(QueueAutoClearModal(server.guild.id));
-}
-
-/**
  * The `/stop_logging` command
  */
 async function stopLogging(
@@ -522,32 +474,6 @@ async function stopLogging(
     );
     await server.setLoggingChannel(undefined);
     await interaction.editReply(SuccessMessages.stoppedLogging);
-}
-
-/**
- * The `/serious_mode` command
-
- */
-async function setSeriousMode(
-    interaction: ChatInputCommandInteraction<'cached'>
-): Promise<void> {
-    const server = AttendingServerV2.get(interaction.guildId);
-    isTriggeredByMemberWithRoles(
-        server,
-        interaction.member,
-        CommandNames.serious_mode,
-        'botAdmin'
-    );
-    const onOrOff = interaction.options.getSubcommand();
-    const warningMessage =
-        server.queues.length < 0 ? ExpectedParseWarnings.noQueuesInServer() : '';
-    if (onOrOff === 'on') {
-        await server.setSeriousServer(true);
-        await interaction.editReply(SuccessMessages.turnedOnSeriousMode(warningMessage));
-    } else {
-        await server.setSeriousServer(false);
-        await interaction.editReply(SuccessMessages.turnedOffSeriousMode(warningMessage));
-    }
 }
 
 /**
@@ -644,50 +570,6 @@ async function settingsMenu(
         'botAdmin'
     );
     await interaction.editReply(SettingsMainMenu(server));
-}
-
-/**
- * The `/auto_give_student_role` command
- */
-async function setAutoGiveStudentRole(
-    interaction: ChatInputCommandInteraction<'cached'>
-): Promise<void> {
-    const server = AttendingServerV2.get(interaction.guildId);
-    isTriggeredByMemberWithRoles(
-        server,
-        interaction.member,
-        CommandNames.auto_give_student_role,
-        'botAdmin'
-    );
-    const onOrOff = interaction.options.getSubcommand();
-    await server.setAutoGiveStudentRole(onOrOff === 'on');
-    await interaction.editReply(
-        onOrOff === 'on'
-            ? SuccessMessages.turnedOnAutoGiveStudentRole
-            : SuccessMessages.turnedOffAutoGiveStudentRole
-    );
-}
-
-/**
- * The `/prompt_help_topic` command
- */
-async function setPromptHelpTopic(
-    interaction: ChatInputCommandInteraction<'cached'>
-): Promise<void> {
-    const server = AttendingServerV2.get(interaction.guildId);
-    isTriggeredByMemberWithRoles(
-        server,
-        interaction.member,
-        CommandNames.prompt_help_topic,
-        'botAdmin'
-    );
-    const onOrOff = interaction.options.getSubcommand();
-    await server.setPromptHelpTopic(onOrOff === 'on');
-    await interaction.editReply(
-        onOrOff === 'on'
-            ? SuccessMessages.turnedOnPromptHelpTopic
-            : SuccessMessages.turnedOffPromptHelpTopic
-    );
 }
 
 /**

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -15,7 +15,10 @@ import {
     updateCommandHelpChannels,
     createOfficeVoiceChannels
 } from '../attending-server/guild-actions.js';
-import { SettingsMainMenu } from '../attending-server/server-settings-menus.js';
+import {
+    SettingsMainMenu,
+    serverSettingsMainMenuOptions
+} from '../attending-server/server-settings-menus.js';
 import { ExpectedParseErrors } from './interaction-constants/expected-interaction-errors.js';
 import { PromptHelpTopicModal } from './interaction-constants/modal-objects.js';
 import { SuccessMessages } from './interaction-constants/success-messages.js';
@@ -569,7 +572,26 @@ async function settingsMenu(
         CommandNames.settings,
         'botAdmin'
     );
-    await interaction.editReply(SettingsMainMenu(server));
+
+    const subMenuJump = interaction.options.getString('sub_menu_jump', false);
+
+    if (subMenuJump === null) {
+        await interaction.editReply(SettingsMainMenu(server));
+        return;
+    }
+
+    // use serverSettingsMainMenuOptions to check if the subMenuJump is valid
+    const subMenuOptions = serverSettingsMainMenuOptions.find(
+        option => option.selectMenuOptionData.value === subMenuJump
+    );
+
+    if (subMenuOptions === undefined) {
+        throw new CommandParseError('Invalid sub menu jump.');
+    }
+
+    await interaction.editReply(
+        subMenuOptions.menu(server, interaction.channelId, false, undefined)
+    );
 }
 
 /**

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -1,4 +1,4 @@
-import { SimpleEmbed, EmbedColor } from '../utils/embed-helper.js';
+import { SimpleEmbed, EmbedColor, BetterEmbed } from '../utils/embed-helper.js';
 import { CommandParseError } from '../utils/error-types.js';
 import {
     convertMsToShortTime,
@@ -10,7 +10,7 @@ import { CommandHandlerProps } from './handler-interface.js';
 // @ts-expect-error the ascii table lib has no type
 import { AsciiTable3, AlignmentEnum } from 'ascii-table3';
 import { CommandNames } from './interaction-constants/interaction-names.js';
-import { ChatInputCommandInteraction } from 'discord.js';
+import { BaseMessageOptions, ChatInputCommandInteraction, EmbedData } from 'discord.js';
 import { adminCommandHelpMessages } from '../../help-channel-messages/AdminCommands.js';
 import { helperCommandHelpMessages } from '../../help-channel-messages/HelperCommands.js';
 import { studentCommandHelpMessages } from '../../help-channel-messages/StudentCommands.js';
@@ -19,7 +19,10 @@ import {
     createOfficeVoiceChannels
 } from '../attending-server/guild-actions.js';
 import { SettingsMainMenu } from '../attending-server/server-settings-menus.js';
-import { ExpectedParseErrors } from './interaction-constants/expected-interaction-errors.js';
+import {
+    ExpectedParseErrors,
+    ExpectedParseWarnings
+} from './interaction-constants/expected-interaction-errors.js';
 import {
     AfterSessionMessageModal,
     PromptHelpTopicModal,
@@ -550,12 +553,14 @@ async function setSeriousMode(
         'botAdmin'
     );
     const onOrOff = interaction.options.getSubcommand();
+    const warningMessage =
+        server.queues.length < 0 ? ExpectedParseWarnings.noQueuesInServer() : '';
     if (onOrOff === 'on') {
         await server.setSeriousServer(true);
-        await interaction.editReply(SuccessMessages.turnedOnSeriousMode);
+        await interaction.editReply(SuccessMessages.turnedOnSeriousMode(warningMessage));
     } else {
         await server.setSeriousServer(false);
-        await interaction.editReply(SuccessMessages.turnedOffSeriousMode);
+        await interaction.editReply(SuccessMessages.turnedOffSeriousMode(warningMessage));
     }
 }
 

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -1,4 +1,4 @@
-import { SimpleEmbed, EmbedColor, BetterEmbed } from '../utils/embed-helper.js';
+import { SimpleEmbed, EmbedColor } from '../utils/embed-helper.js';
 import { CommandParseError } from '../utils/error-types.js';
 import {
     convertMsToShortTime,
@@ -10,7 +10,7 @@ import { CommandHandlerProps } from './handler-interface.js';
 // @ts-expect-error the ascii table lib has no type
 import { AsciiTable3, AlignmentEnum } from 'ascii-table3';
 import { CommandNames } from './interaction-constants/interaction-names.js';
-import { BaseMessageOptions, ChatInputCommandInteraction, EmbedData } from 'discord.js';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { adminCommandHelpMessages } from '../../help-channel-messages/AdminCommands.js';
 import { helperCommandHelpMessages } from '../../help-channel-messages/HelperCommands.js';
 import { studentCommandHelpMessages } from '../../help-channel-messages/StudentCommands.js';

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -719,10 +719,14 @@ async function joinQueueNotify(
     const onOrOff = interaction.options.getSubcommand(true);
 
     if (onOrOff === 'on') {
-        await server.addStudentToNotifGroup(interaction.member, queue);
+        await server
+            .getQueueById(queue.parentCategoryId)
+            .addToNotifGroup(interaction.member);
         await interaction.editReply(SuccessMessages.joinedNotif(queue.queueName));
     } else if (onOrOff === 'off') {
-        await server.removeStudentFromNotifGroup(interaction.member, queue);
+        await server
+            .getQueueById(queue.parentCategoryId)
+            .removeFromNotifGroup(interaction.member);
         await interaction.editReply(SuccessMessages.removedNotif(queue.queueName));
     } else {
         throw new CommandParseError('Invalid subcommand.');

--- a/src/interaction-handling/handler-interface.ts
+++ b/src/interaction-handling/handler-interface.ts
@@ -2,7 +2,7 @@ import type {
     ButtonInteraction,
     ChatInputCommandInteraction,
     ModalSubmitInteraction,
-    SelectMenuInteraction
+    StringSelectMenuInteraction
 } from 'discord.js';
 
 /** ChatInputCommands can only exist in guilds, so we can assume it will always be cached */
@@ -15,10 +15,10 @@ type GuildButtonHandler = (interaction: ButtonInteraction<'cached'>) => Promise<
 type DMButtonHandler = (interaction: ButtonInteraction) => Promise<void>;
 
 type GuildSelectMenuHandler = (
-    interaction: SelectMenuInteraction<'cached'>
+    interaction: StringSelectMenuInteraction<'cached'>
 ) => Promise<void>;
 
-type DMSelectMenuHandler = (interaction: SelectMenuInteraction) => Promise<void>;
+type DMSelectMenuHandler = (interaction: StringSelectMenuInteraction) => Promise<void>;
 
 type GuildModalSubmitHandler = (
     interaction: ModalSubmitInteraction<'cached'>

--- a/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
+++ b/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
@@ -121,6 +121,35 @@ const clearAllCommand = new SlashCommandBuilder()
     .setName(CommandNames.clear_all)
     .setDescription('Admin only. Clears all the queues on this server');
 
+// /queue_notify [queue_name] [on | off]
+const queueNotifyCommand = new SlashCommandBuilder()
+    .setName(CommandNames.queue_notify)
+    .setDescription('Toggle whether you want to be pinged when you are next in line')
+    .addSubcommand(subcommand =>
+        subcommand // /queue_notify on [queue_name]
+            .setName('on')
+            .setDescription('Turn on notifications for a queue')
+            .addChannelOption(option =>
+                option
+                    .setName('queue_name')
+                    .setDescription('The queue to turn on notifications for')
+                    .setRequired(true)
+                    .addChannelTypes(ChannelType.GuildCategory)
+            )
+    )
+    .addSubcommand(subcommand =>
+        subcommand // /queue_notify off [queue_name]
+            .setName('off')
+            .setDescription('Turn off notifications for a queue')
+            .addChannelOption(option =>
+                option
+                    .setName('queue_name')
+                    .setDescription('The queue to turn off notifications for')
+                    .setRequired(true)
+                    .addChannelTypes(ChannelType.GuildCategory)
+            )
+    );
+
 // /announce [message] (queue_name)
 const announceCommand = new SlashCommandBuilder()
     .setName(CommandNames.announce)
@@ -283,16 +312,19 @@ const autoGiveStudentRoleCommand = new SlashCommandBuilder()
         subcommand.setName('off').setDescription('Turns off auto giving student role')
     );
 
+// /pause
 const pauseCommand = new SlashCommandBuilder()
     .setName(CommandNames.pause)
     .setDescription(
         'Prevents students from joining the queue, but allows the helper to dequeue.'
     );
 
+// /resume
 const resumeCommand = new SlashCommandBuilder()
     .setName(CommandNames.resume)
     .setDescription('Allow students to join the queue again after /pause was used.');
 
+// /prompt_help_topic {on|off}
 const promptHelpTopicCommand = new SlashCommandBuilder()
     .setName(CommandNames.prompt_help_topic)
     .setDescription(
@@ -344,6 +376,7 @@ const commandData = [
     leaveCommand.toJSON(),
     clearCommand.toJSON(),
     clearAllCommand.toJSON(),
+    queueNotifyCommand.toJSON(),
     listHelpersCommand.toJSON(),
     announceCommand.toJSON(),
     cleanupQueue.toJSON(),

--- a/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
+++ b/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
@@ -278,7 +278,7 @@ function generateSettingsCommand() {
         .setDescription('Sets up the server config for the bot')
         .addStringOption(option =>
             option
-                .setName('sub_menu')
+                .setName('sub_menu_jump')
                 .setDescription('The sub menu to jump to')
                 .setRequired(false)
                 .addChoices(

--- a/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
+++ b/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
@@ -196,18 +196,6 @@ const cleanupHelpChannelCommand = new SlashCommandBuilder()
     .setName(CommandNames.cleanup_help_channels)
     .setDescription('Debug feature: Force updates the command help channels');
 
-// /set_after_session_message
-const setAfterSessionMessageCommand = new SlashCommandBuilder()
-    .setName(CommandNames.set_after_session_msg)
-    .setDescription(
-        'Sets the message automatically sent to students after they leave the voice chat'
-    );
-
-// /set_queue_auto_clear
-const setQueueAutoClear = new SlashCommandBuilder()
-    .setName(CommandNames.set_queue_auto_clear)
-    .setDescription('Sets the timeout before automatically clearing all the queues');
-
 // /set_logging_channel [channel]
 const setLoggingChannelCommand = new SlashCommandBuilder()
     .setName(CommandNames.set_logging_channel)
@@ -224,17 +212,6 @@ const setLoggingChannelCommand = new SlashCommandBuilder()
 const stopLoggingCommand = new SlashCommandBuilder()
     .setName(CommandNames.stop_logging)
     .setDescription('Stops the bot from logging events');
-
-// /serious_mode [enable]
-const activateSeriousModeCommand = new SlashCommandBuilder()
-    .setName(CommandNames.serious_mode)
-    .setDescription('Activates serious mode')
-    .addSubcommand(subcommand =>
-        subcommand.setName('on').setDescription('Turns on serious mode')
-    )
-    .addSubcommand(subcommand =>
-        subcommand.setName('off').setDescription('Turns off serious mode')
-    );
 
 // /create_offices [category_name] [office_name] [number_of_offices]
 const createOfficesCommand = new SlashCommandBuilder()
@@ -298,17 +275,6 @@ const settingsCommand = new SlashCommandBuilder()
     .setName(CommandNames.settings)
     .setDescription('Sets up the server config for the bot');
 
-// /auto_give_student_role {on|off}
-const autoGiveStudentRoleCommand = new SlashCommandBuilder()
-    .setName(CommandNames.auto_give_student_role)
-    .setDescription('Automatically gives the student role to new members')
-    .addSubcommand(subcommand =>
-        subcommand.setName('on').setDescription('Turns on auto giving student role')
-    )
-    .addSubcommand(subcommand =>
-        subcommand.setName('off').setDescription('Turns off auto giving student role')
-    );
-
 // /pause
 const pauseCommand = new SlashCommandBuilder()
     .setName(CommandNames.pause)
@@ -321,29 +287,9 @@ const resumeCommand = new SlashCommandBuilder()
     .setName(CommandNames.resume)
     .setDescription('Allow students to join the queue again after /pause was used.');
 
-// /prompt_help_topic {on|off}
-const promptHelpTopicCommand = new SlashCommandBuilder()
-    .setName(CommandNames.prompt_help_topic)
-    .setDescription(
-        'Enable or disable the modal that prompts the student to enter what they need help with'
-    )
-    .addSubcommand(subcommand =>
-        subcommand.setName('on').setDescription('Turns on the prompt')
-    )
-    .addSubcommand(subcommand =>
-        subcommand.setName('off').setDescription('Turns off the prompt')
-    );
-
-// /help
-/**
- * Generates the help command based on adminCommandHelpMessages,
- * helperCommandHelpMessages,and studentCommandHelpMessages
- */
-function generateHelpCommand() {
-    return new SlashCommandBuilder()
-        .setName(CommandNames.help)
-        .setDescription('Get help with the bot');
-}
+const helpCommand = new SlashCommandBuilder()
+    .setName(CommandNames.help)
+    .setDescription('Get help with the bot');
 
 /** The raw data that can be sent to Discord */
 const commandData = [
@@ -361,18 +307,14 @@ const commandData = [
     cleanupQueue.toJSON(),
     cleanupAllQueues.toJSON(),
     cleanupHelpChannelCommand.toJSON(),
-    setAfterSessionMessageCommand.toJSON(),
     setLoggingChannelCommand.toJSON(),
     stopLoggingCommand.toJSON(),
-    setQueueAutoClear.toJSON(),
-    activateSeriousModeCommand.toJSON(),
     createOfficesCommand.toJSON(),
     setRolesCommand.toJSON(),
     settingsCommand.toJSON(),
-    autoGiveStudentRoleCommand.toJSON(),
     pauseCommand.toJSON(),
     resumeCommand.toJSON(),
-    promptHelpTopicCommand.toJSON()
+    helpCommand.toJSON()
 ];
 
 async function postSlashCommands(
@@ -396,7 +338,7 @@ async function postSlashCommands(
             ),
             {
                 // need to call generateHelpCommand() here because it needs to be called after the external help messages are added
-                body: commandData.concat(externalCommands, generateHelpCommand().toJSON())
+                body: commandData.concat(externalCommands)
             }
         )
         .catch(e =>

--- a/src/interaction-handling/interaction-constants/expected-interaction-errors.ts
+++ b/src/interaction-handling/interaction-constants/expected-interaction-errors.ts
@@ -34,7 +34,7 @@ const ExpectedParseErrors = {
     missingAccessLevelRolesVariant: (
         lowestRequiredRoleName: Optional<string>,
         commandName: string,
-        lowestRequiredRoleID: Snowflake,
+        lowestRequiredRoleID: Snowflake
     ): CommandParseError =>
         lowestRequiredRoleName
             ? new CommandParseError(

--- a/src/interaction-handling/interaction-constants/expected-interaction-errors.ts
+++ b/src/interaction-handling/interaction-constants/expected-interaction-errors.ts
@@ -148,4 +148,27 @@ const UnexpectedParseErrors = {
         )
 } as const;
 
-export { ExpectedParseErrors, UnexpectedParseErrors };
+const ExpectedParseWarnings = {
+    missingRoles: (missingRoleNames: string[]): string =>
+        `This command works for you due to admin permission override` +
+        `The roles ${missingRoleNames.join(', ')}` +
+        ` does not exist on this server or have not been set up. You can use \`/settings\` -> Server Roles to configure roles.`,
+    missingAccessLevelRoles: (
+        lowestRequiredRoleID: Snowflake,
+        commandName: string
+    ): string =>
+        `You need to have the role <@&${lowestRequiredRoleID}> or higher to use the \`${commandName}\` command.`,
+    missingAccessLevelRolesVariant: (
+        lowestRequiredRoleName: Optional<string>,
+        commandName: string,
+        lowestRequiredRoleID: Snowflake
+    ): string =>
+        lowestRequiredRoleName
+            ? `You need to have the role \`${lowestRequiredRoleName}\` or higher to use the \`${commandName}\` command. ` +
+              `The ${lowestRequiredRoleName} role on this server is <@&${lowestRequiredRoleID}>`
+            : `Some access level roles have not been set up on this server. Please ask the server owner to use /set_roles or the settings menu to set it up.`,
+    noQueuesInServer: (): string =>
+        `This command doesn't have any effect since server doesn't have any queues. `
+} as const;
+
+export { ExpectedParseErrors, UnexpectedParseErrors, ExpectedParseWarnings };

--- a/src/interaction-handling/interaction-constants/interaction-names.ts
+++ b/src/interaction-handling/interaction-constants/interaction-names.ts
@@ -26,14 +26,9 @@ enum CommandNames {
     queue_notify = 'queue_notify',
     set_logging_channel = 'set_logging_channel',
     stop_logging = 'stop_logging',
-    serious_mode = 'serious_mode',
     create_offices = 'create_offices',
     set_roles = 'set_roles',
-    settings = 'settings',
-    auto_give_student_role = 'auto_give_student_role',
-    prompt_help_topic = 'prompt_help_topic',
-    set_after_session_msg = 'set_after_session_msg',
-    set_queue_auto_clear = 'set_queue_auto_clear'
+    settings = 'settings'
 }
 
 /**

--- a/src/interaction-handling/interaction-constants/interaction-names.ts
+++ b/src/interaction-handling/interaction-constants/interaction-names.ts
@@ -23,6 +23,7 @@ enum CommandNames {
     resume = 'resume',
     stop = 'stop',
     help = 'help',
+    queue_notify = 'queue_notify',
     set_logging_channel = 'set_logging_channel',
     stop_logging = 'stop_logging',
     serious_mode = 'serious_mode',

--- a/src/interaction-handling/interaction-constants/success-messages.ts
+++ b/src/interaction-handling/interaction-constants/success-messages.ts
@@ -10,7 +10,7 @@ export const SuccessMessages = {
     createdQueue: (queueName: string) =>
         SimpleEmbed(
             `Successfully created \`${queueName}\`. It should be at the end of your channels list.`,
-            EmbedColor.Success
+            EmbedColor.Success,
         ),
     deletedQueue: (queueName: string) =>
         SimpleEmbed(`Successfully deleted \`${queueName}\`.`, EmbedColor.Success),
@@ -104,13 +104,17 @@ export const SuccessMessages = {
             EmbedColor.Success
         )
     },
-    turnedOnSeriousMode: SimpleEmbed(
+    turnedOnSeriousMode: (warningMessage?: string) => SimpleEmbed(
         `Serious mode has been turned on.`,
-        EmbedColor.Success
+        EmbedColor.Success,
+        '',
+        warningMessage
     ),
-    turnedOffSeriousMode: SimpleEmbed(
+    turnedOffSeriousMode: (warningMessage? : string) => SimpleEmbed(
         `Serious mode has been turned off.\nThere's no need to be so serious!`,
-        EmbedColor.Success
+        EmbedColor.Success,
+        '',
+        warningMessage
     ),
     createdOffices: (numOffices: number) =>
         SimpleEmbed(

--- a/src/interaction-handling/interaction-constants/success-messages.ts
+++ b/src/interaction-handling/interaction-constants/success-messages.ts
@@ -10,7 +10,7 @@ export const SuccessMessages = {
     createdQueue: (queueName: string) =>
         SimpleEmbed(
             `Successfully created \`${queueName}\`. It should be at the end of your channels list.`,
-            EmbedColor.Success,
+            EmbedColor.Success
         ),
     deletedQueue: (queueName: string) =>
         SimpleEmbed(`Successfully deleted \`${queueName}\`.`, EmbedColor.Success),
@@ -104,18 +104,20 @@ export const SuccessMessages = {
             EmbedColor.Success
         )
     },
-    turnedOnSeriousMode: (warningMessage?: string) => SimpleEmbed(
-        `Serious mode has been turned on.`,
-        EmbedColor.Success,
-        '',
-        warningMessage
-    ),
-    turnedOffSeriousMode: (warningMessage? : string) => SimpleEmbed(
-        `Serious mode has been turned off.\nThere's no need to be so serious!`,
-        EmbedColor.Success,
-        '',
-        warningMessage
-    ),
+    turnedOnSeriousMode: (warningMessage?: string) =>
+        SimpleEmbed(
+            `Serious mode has been turned on.`,
+            EmbedColor.Success,
+            '',
+            warningMessage
+        ),
+    turnedOffSeriousMode: (warningMessage?: string) =>
+        SimpleEmbed(
+            `Serious mode has been turned off.\nThere's no need to be so serious!`,
+            EmbedColor.Success,
+            '',
+            warningMessage
+        ),
     createdOffices: (numOffices: number) =>
         SimpleEmbed(
             `Successfully created ${numOffices} office${

--- a/src/interaction-handling/interaction-entry-point.ts
+++ b/src/interaction-handling/interaction-entry-point.ts
@@ -155,11 +155,11 @@ async function processButton(interaction: Interaction): Promise<void> {
 }
 
 /**
- * Process SelectMenuInteractions
+ * Process StringSelectMenuInteractions
  * @param interaction
  */
 async function processSelectMenu(interaction: Interaction): Promise<void> {
-    if (!interaction.isSelectMenu()) {
+    if (!interaction.isStringSelectMenu()) {
         return;
     }
     const [type, selectMenuName, serverId] = decompressComponentId(interaction.customId);
@@ -252,7 +252,7 @@ function getHandler(interaction: Interaction): (i: Interaction) => Promise<void>
     if (interaction.isModalSubmit()) {
         return processModalSubmit;
     }
-    if (interaction.isSelectMenu()) {
+    if (interaction.isStringSelectMenu()) {
         return processSelectMenu;
     }
     if (interaction.isButton()) {

--- a/src/interaction-handling/select-menu-handler.ts
+++ b/src/interaction-handling/select-menu-handler.ts
@@ -38,7 +38,7 @@ async function showSettingsSubMenu(
     const server = AttendingServerV2.get(interaction.guildId);
     const selectedOption = interaction.values[0];
     const callbackMenu = serverSettingsMainMenuOptions.find(
-        option => option.optionData.value === selectedOption
+        option => option.selectMenuOptionData.value === selectedOption
     )?.menu;
     if (!callbackMenu) {
         throw new Error(`Invalid option selected: ${selectedOption}`);
@@ -59,7 +59,7 @@ async function selectLoggingChannel(
     const channelId = interaction.values[0];
     const loggingChannel = server.guild.channels.cache.get(channelId ?? '');
     const callbackMenu = serverSettingsMainMenuOptions.find(
-        option => option.optionData.value === 'logging-channel'
+        option => option.selectMenuOptionData.value === 'logging-channel'
     );
     if (!loggingChannel || !isTextChannel(loggingChannel)) {
         throw ExpectedParseErrors.nonExistentTextChannel(channelId);

--- a/src/interaction-handling/select-menu-handler.ts
+++ b/src/interaction-handling/select-menu-handler.ts
@@ -1,4 +1,4 @@
-import { SelectMenuInteraction } from 'discord.js';
+import { StringSelectMenuInteraction } from 'discord.js';
 import { serverSettingsMainMenuOptions } from '../attending-server/server-settings-menus.js';
 import { isTextChannel } from '../utils/util-functions.js';
 import { SelectMenuHandlerProps } from './handler-interface.js';
@@ -33,7 +33,7 @@ const baseYabobSelectMenuMap: SelectMenuHandlerProps = {
  * @param interaction
  */
 async function showSettingsSubMenu(
-    interaction: SelectMenuInteraction<'cached'>
+    interaction: StringSelectMenuInteraction<'cached'>
 ): Promise<void> {
     const server = AttendingServerV2.get(interaction.guildId);
     const selectedOption = interaction.values[0];
@@ -53,7 +53,7 @@ async function showSettingsSubMenu(
  * @param interaction
  */
 async function selectLoggingChannel(
-    interaction: SelectMenuInteraction<'cached'>
+    interaction: StringSelectMenuInteraction<'cached'>
 ): Promise<void> {
     const server = AttendingServerV2.get(interaction.guildId);
     const channelId = interaction.values[0];
@@ -83,7 +83,7 @@ async function selectLoggingChannel(
  * @param interaction
  */
 async function selectHelpCommand(
-    interaction: SelectMenuInteraction<'cached'>
+    interaction: StringSelectMenuInteraction<'cached'>
 ): Promise<void> {
     const server = AttendingServerV2.get(interaction.guildId);
     const selectedOption = interaction.values[0];

--- a/src/interaction-handling/shared-interaction-functions.ts
+++ b/src/interaction-handling/shared-interaction-functions.ts
@@ -43,7 +43,7 @@ function HelpMainMenuEmbed(
     if (viewMode === 'botAdmin') {
         embed.addFields([
             {
-                name: 'Admin Commands',
+                name: ' 👮 Bot Admin Commands',
                 value: 'Commands for bot admins to use to manage the bot.'
             }
         ]);
@@ -55,7 +55,7 @@ function HelpMainMenuEmbed(
                 UnknownId
             ])
                 .setStyle(ButtonStyle.Primary)
-                .setLabel('Admin Commands')
+                .setLabel('Bot Admin Commands')
                 .setEmoji('👮')
         );
     }
@@ -63,7 +63,7 @@ function HelpMainMenuEmbed(
     // Helper commands
     embed.addFields([
         {
-            name: 'Helper Commands',
+            name: '👨‍🏫 Helper Commands',
             value: 'Commands for helpers to use to manage the help channels.'
         }
     ]);
@@ -82,7 +82,7 @@ function HelpMainMenuEmbed(
     // Student commands
     embed.addFields([
         {
-            name: 'Student Commands',
+            name: '👨‍🎓 Student Commands',
             value: 'Commands for students to use to interact with the help channels.'
         }
     ]);
@@ -124,41 +124,45 @@ function HelpSubMenuEmbed(
             : studentCommandHelpMessages
     ).filter(helpMessage => helpMessage.useInHelpCommand === true);
 
-    // create select menu from the help messages
-    const selectMenu = HelpMenuSelectMenu(server, page, subMenu);
-
     const embed = new EmbedBuilder()
         .setTitle(
             `${
                 subMenu === 'botAdmin'
-                    ? 'Admin'
+                    ? '👮 Bot Admin'
                     : subMenu === 'staff'
-                    ? 'Staff'
-                    : 'Student'
+                    ? '👨‍🏫 Staff'
+                    : '👨‍🎓 Student'
             } Help Menu`
         )
         .setColor(EmbedColor.Pink)
         .setDescription(
             'This is the help menu for YABOB. Use the buttons below to navigate through the menu.'
-        )
-        .setFooter({
-            text: `Page ${page + 1}/${Math.ceil(allHelpMessages.length / 25)}`
+        );
+
+    const numPages = Math.ceil(allHelpMessages.length / 25);
+    if (numPages > 1) {
+        embed.setFooter({
+            text: `Page ${page + 1}/${numPages}`
         });
+    }
 
     return {
         embeds: [embed],
         components:
-            Math.floor(allHelpMessages.length / 25) >= 2
+            Math.floor(allHelpMessages.length / 25) >= 2 // Only show the turn page buttons if there are 2 or more pages
                 ? [
                       HelpMenuButtons(
                           server,
                           page,
                           Math.floor(allHelpMessages.length / 25)
                       ),
-                      selectMenu,
+                      HelpMenuSelectMenu(server, page, subMenu),
                       ReturnToHelpMainMenuButton(server)
                   ]
-                : [selectMenu, ReturnToHelpMainMenuButton(server)]
+                : [
+                      HelpMenuSelectMenu(server, page, subMenu),
+                      ReturnToHelpMainMenuButton(server)
+                  ]
     };
 }
 

--- a/src/interaction-handling/shared-interaction-functions.ts
+++ b/src/interaction-handling/shared-interaction-functions.ts
@@ -1,6 +1,6 @@
 import {
     ActionRowBuilder,
-    SelectMenuBuilder,
+    StringSelectMenuBuilder,
     ButtonBuilder,
     ButtonStyle,
     EmbedBuilder
@@ -208,7 +208,7 @@ function HelpMenuSelectMenu(
     server: AttendingServerV2,
     page: number,
     subMenu: AccessLevelRole = 'student'
-): ActionRowBuilder<SelectMenuBuilder> {
+): ActionRowBuilder<StringSelectMenuBuilder> {
     const allHelpMessages = (
         subMenu === 'botAdmin'
             ? adminCommandHelpMessages
@@ -219,8 +219,8 @@ function HelpMenuSelectMenu(
 
     const pageHelpMessages = allHelpMessages.slice(page * 25, (page + 1) * 25);
 
-    const selectMenu = new ActionRowBuilder<SelectMenuBuilder>().addComponents(
-        buildComponent(new SelectMenuBuilder(), [
+    const selectMenu = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        buildComponent(new StringSelectMenuBuilder(), [
             'other',
             SelectMenuNames.HelpMenu,
             server.guild.id,

--- a/src/interaction-handling/shared-validations.ts
+++ b/src/interaction-handling/shared-validations.ts
@@ -5,7 +5,7 @@ import {
     Interaction,
     ModalSubmitInteraction,
     PermissionsBitField,
-    SelectMenuInteraction
+    StringSelectMenuInteraction
 } from 'discord.js';
 import {
     AttendingServerV2,
@@ -30,7 +30,7 @@ import { CategoryChannelId } from '../utils/type-aliases.js';
  * @returns the {@link AttendingServerV2} object
  */
 function isValidDMInteraction(
-    interaction: ButtonInteraction | ModalSubmitInteraction | SelectMenuInteraction
+    interaction: ButtonInteraction | ModalSubmitInteraction | StringSelectMenuInteraction
 ): AttendingServerV2 {
     const [type, , serverId] = decompressComponentId(interaction.customId);
     if (type !== 'dm') {

--- a/src/utils/component-id-factory.ts
+++ b/src/utils/component-id-factory.ts
@@ -8,7 +8,7 @@ import {
     Optional
 } from './type-aliases.js';
 import LZString from 'lz-string';
-import { ButtonBuilder, ModalBuilder, SelectMenuBuilder } from 'discord.js';
+import { ButtonBuilder, ModalBuilder, StringSelectMenuBuilder } from 'discord.js';
 import { CommandParseError } from './error-types.js';
 
 /** A tuple that represents the information encoded in a custom id */
@@ -47,7 +47,7 @@ const UnknownId = '0' as const;
  */
 function buildComponent<
     T extends ComponentLocation,
-    R extends ButtonBuilder | ModalBuilder | SelectMenuBuilder
+    R extends ButtonBuilder | ModalBuilder | StringSelectMenuBuilder
 >(builder: R, idInfo: CustomIdTuple<T>): R {
     builder.setCustomId(LZString.compressToUTF16(JSON.stringify(idInfo)));
     return builder;
@@ -153,7 +153,7 @@ class YabobButton<T extends ComponentLocation> extends ButtonBuilder {
     }
 }
 
-class YabobSelectMenu<T extends ComponentLocation> extends SelectMenuBuilder {
+class YabobSelectMenu<T extends ComponentLocation> extends StringSelectMenuBuilder {
     constructor(idInfo: CustomIdTuple<T>) {
         super();
         super.setCustomId(LZString.compressToUTF16(JSON.stringify(idInfo)));

--- a/src/utils/embed-helper.ts
+++ b/src/utils/embed-helper.ts
@@ -7,14 +7,7 @@ import {
     TextBasedChannel,
     User,
     ApplicationCommandOptionType,
-    EmbedBuilder,
-    ActionRowComponentOptions,
-    MessageActionRowComponentData,
-    ActionRowData,
-    MessageActionRowComponentBuilder,
-    Attachment,
-    AttachmentBuilder,
-    AttachmentPayload
+    EmbedBuilder
 } from 'discord.js';
 import { CommandParseError, QueueError, ServerError } from '../utils/error-types.js';
 import { client } from '../global-states.js';
@@ -24,107 +17,6 @@ type ExpectedError = QueueError | ServerError | CommandParseError;
 
 /** Shorthand type for the embed field data */
 type EmbedData = Pick<BaseMessageOptions, 'embeds'>;
-
-class BetterEmbed implements BaseMessageOptions {
-    embeds: EmbedBuilder[] = [];
-    files?: (
-        | Attachment
-        | AttachmentBuilder
-        | AttachmentPayload
-    )[];
-    content?: string;
-    components?: ActionRowData<MessageActionRowComponentData | MessageActionRowComponentBuilder>[];
-    constructor() {
-        this.embeds = [];
-    }
-    addFields(fields: { name: string; value: string; inline?: boolean }[]): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].addFields(fields);
-        return this;
-    }
-    addDescription(description: string): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setDescription(description);
-        return this;
-    }
-    addFooter(text: string, iconURL?: string): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setFooter({
-                text: text,
-                iconURL: iconURL
-        });
-        return this;
-    }
-    addTimestamp(): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setTimestamp();
-        return this;
-    }
-    addAuthor(name: string, iconURL?: string, url?: string): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setAuthor({
-                name: name,
-                iconURL: iconURL,
-                url: url
-        });
-        return this;
-    }
-    setColor(color: number): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setColor(color);
-        return this;
-    }
-    setTitle(title: string): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setTitle(title);
-        return this;
-    }
-    setImage(url: string): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setImage(url);
-        return this;
-    }
-    setThumbnail(url: string): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setThumbnail(url);
-        return this;
-    }
-    setURL(url: string): BetterEmbed {
-        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
-        this.embeds[0].setURL(url);
-        return this;
-    }
-    addFile(file: Attachment | AttachmentBuilder | AttachmentPayload): BetterEmbed {
-        this.files = this.files ?? [];
-        this.files.push(file);
-        return this;
-    }
-    addFiles(files: (Attachment | AttachmentBuilder | AttachmentPayload)[]): BetterEmbed {
-        this.files = this.files ?? [];
-        this.files.push(...files);
-        return this;
-    }
-    setContent(content: string): BetterEmbed {
-        this.content = content;
-        return this;
-    }
-    addComponents(components: ActionRowData<MessageActionRowComponentData | MessageActionRowComponentBuilder>[]): BetterEmbed {
-        this.components = components;
-        return this;
-    }
-    getFields(): { name: string; value: string; inline?: boolean }[] {
-        if(!this.embeds[0]) throw new Error('Embed doesn\'t exist'); 
-        const embedDataFields = this.embeds[0].data.fields;
-        return embedDataFields?.map(
-            field => { return {
-                name: field.name,
-                value: field.value,
-                inline: field.inline
-            };
-        }) ?? [];
-    }
-    
-}
 
 enum EmbedColor {
     Error = 0xff6188, // Red
@@ -229,9 +121,6 @@ function SimpleEmbed2(
 
     return embed;
 }
-
-let asdf = SimpleEmbed2('asdf', EmbedColor.Neutral, 'asdf', 'asdf');
-interaction.reply(asdf.data);
 
 /**
  * Creates an embed that displays an error message
@@ -767,7 +656,6 @@ function SelectMenuLogEmbed2(
 
 export {
     EmbedColor,
-    BetterEmbed,
     SimpleEmbed,
     SimpleEmbed2,
     SimpleLogEmbed,

--- a/src/utils/embed-helper.ts
+++ b/src/utils/embed-helper.ts
@@ -7,7 +7,14 @@ import {
     TextBasedChannel,
     User,
     ApplicationCommandOptionType,
-    EmbedBuilder
+    EmbedBuilder,
+    ActionRowComponentOptions,
+    MessageActionRowComponentData,
+    ActionRowData,
+    MessageActionRowComponentBuilder,
+    Attachment,
+    AttachmentBuilder,
+    AttachmentPayload
 } from 'discord.js';
 import { CommandParseError, QueueError, ServerError } from '../utils/error-types.js';
 import { client } from '../global-states.js';
@@ -17,6 +24,107 @@ type ExpectedError = QueueError | ServerError | CommandParseError;
 
 /** Shorthand type for the embed field data */
 type EmbedData = Pick<BaseMessageOptions, 'embeds'>;
+
+class BetterEmbed implements BaseMessageOptions {
+    embeds: EmbedBuilder[] = [];
+    files?: (
+        | Attachment
+        | AttachmentBuilder
+        | AttachmentPayload
+    )[];
+    content?: string;
+    components?: ActionRowData<MessageActionRowComponentData | MessageActionRowComponentBuilder>[];
+    constructor() {
+        this.embeds = [];
+    }
+    addFields(fields: { name: string; value: string; inline?: boolean }[]): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].addFields(fields);
+        return this;
+    }
+    addDescription(description: string): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setDescription(description);
+        return this;
+    }
+    addFooter(text: string, iconURL?: string): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setFooter({
+                text: text,
+                iconURL: iconURL
+        });
+        return this;
+    }
+    addTimestamp(): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setTimestamp();
+        return this;
+    }
+    addAuthor(name: string, iconURL?: string, url?: string): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setAuthor({
+                name: name,
+                iconURL: iconURL,
+                url: url
+        });
+        return this;
+    }
+    setColor(color: number): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setColor(color);
+        return this;
+    }
+    setTitle(title: string): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setTitle(title);
+        return this;
+    }
+    setImage(url: string): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setImage(url);
+        return this;
+    }
+    setThumbnail(url: string): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setThumbnail(url);
+        return this;
+    }
+    setURL(url: string): BetterEmbed {
+        if(!this.embeds[0]) throw new Error('No embeds to add field to'); 
+        this.embeds[0].setURL(url);
+        return this;
+    }
+    addFile(file: Attachment | AttachmentBuilder | AttachmentPayload): BetterEmbed {
+        this.files = this.files ?? [];
+        this.files.push(file);
+        return this;
+    }
+    addFiles(files: (Attachment | AttachmentBuilder | AttachmentPayload)[]): BetterEmbed {
+        this.files = this.files ?? [];
+        this.files.push(...files);
+        return this;
+    }
+    setContent(content: string): BetterEmbed {
+        this.content = content;
+        return this;
+    }
+    addComponents(components: ActionRowData<MessageActionRowComponentData | MessageActionRowComponentBuilder>[]): BetterEmbed {
+        this.components = components;
+        return this;
+    }
+    getFields(): { name: string; value: string; inline?: boolean }[] {
+        if(!this.embeds[0]) throw new Error('Embed doesn\'t exist'); 
+        const embedDataFields = this.embeds[0].data.fields;
+        return embedDataFields?.map(
+            field => { return {
+                name: field.name,
+                value: field.value,
+                inline: field.inline
+            };
+        }) ?? [];
+    }
+    
+}
 
 enum EmbedColor {
     Error = 0xff6188, // Red
@@ -95,7 +203,7 @@ function SimpleEmbed2(
     color = EmbedColor.Neutral,
     description = '',
     warning = ''
-): EmbedData {
+): EmbedBuilder {
     const YABOB_PFP_URL = client.user.avatarURL() ?? DEFAULT_PFP;
     const embed = new EmbedBuilder()
         .setColor(color)
@@ -119,8 +227,11 @@ function SimpleEmbed2(
         });
     }
 
-    return { embeds: [embed.data] };
+    return embed;
 }
+
+let asdf = SimpleEmbed2('asdf', EmbedColor.Neutral, 'asdf', 'asdf');
+interaction.reply(asdf.data);
 
 /**
  * Creates an embed that displays an error message
@@ -656,6 +767,7 @@ function SelectMenuLogEmbed2(
 
 export {
     EmbedColor,
+    BetterEmbed,
     SimpleEmbed,
     SimpleEmbed2,
     SimpleLogEmbed,

--- a/src/utils/embed-helper.ts
+++ b/src/utils/embed-helper.ts
@@ -48,7 +48,8 @@ const DEFAULT_PFP = 'https://i.postimg.cc/dVkg4XFf/BOB-pfp.png' as const;
 function SimpleEmbed(
     message: string,
     color = EmbedColor.Neutral,
-    description = ''
+    description = '',
+    warning = ''
 ): EmbedData {
     const YABOB_PFP_URL = client.user.avatarURL() ?? DEFAULT_PFP;
     if (message.length <= 256) {
@@ -59,6 +60,8 @@ function SimpleEmbed(
                     title: message,
                     timestamp: new Date().toISOString(),
                     description: description.slice(0, 4096),
+                    fields:
+                        warning.length > 0 ? [{ name: 'Warning', value: warning }] : [],
                     author: {
                         name: 'YABOB',
                         icon_url: YABOB_PFP_URL
@@ -73,6 +76,8 @@ function SimpleEmbed(
                 {
                     color: color,
                     description: (message + '\n\n' + description).slice(0, 4096),
+                    fields:
+                        warning.length > 0 ? [{ name: 'Warning', value: warning }] : [],
                     timestamp: new Date().toISOString(),
                     author: {
                         name: 'YABOB',
@@ -88,7 +93,8 @@ function SimpleEmbed(
 function SimpleEmbed2(
     message: string,
     color = EmbedColor.Neutral,
-    description = ''
+    description = '',
+    warning = ''
 ): EmbedData {
     const YABOB_PFP_URL = client.user.avatarURL() ?? DEFAULT_PFP;
     const embed = new EmbedBuilder()
@@ -106,6 +112,13 @@ function SimpleEmbed2(
             embed.setDescription(description.slice(0, 4096));
         }
     }
+    if (warning.length > 0) {
+        embed.addFields({
+            name: 'Warning',
+            value: warning
+        });
+    }
+
     return { embeds: [embed.data] };
 }
 

--- a/src/utils/type-aliases.ts
+++ b/src/utils/type-aliases.ts
@@ -153,7 +153,7 @@ type EnsureCorrectEnum<T extends { [K in Exclude<keyof T, number>]: K }> = true;
 /**
  * Represents 1 option inside the main settings menu
  *
- * `selectMenuOptionData` is directly passed to the SelectMenuBuilder.addOptions method
+ * `selectMenuOptionData` is directly passed to the StringSelectMenuBuilder.addOptions method
  *
  * `useInSettingsCommand` is whether to use in /settings options
  *
@@ -161,7 +161,7 @@ type EnsureCorrectEnum<T extends { [K in Exclude<keyof T, number>]: K }> = true;
  * */
 type SettingsMenuOption = {
     /**
-     * This is directly passed to the SelectMenuBuilder.addOptions method
+     * This is directly passed to the StringSelectMenuBuilder.addOptions method
      */
     selectMenuOptionData: SelectMenuComponentOptionData;
     /**

--- a/src/utils/type-aliases.ts
+++ b/src/utils/type-aliases.ts
@@ -150,12 +150,25 @@ type Entries<T> = {
  */
 type EnsureCorrectEnum<T extends { [K in Exclude<keyof T, number>]: K }> = true;
 
-/** Represents 1 option inside the main settings menu */
+/**
+ * Represents 1 option inside the main settings menu
+ *
+ * `selectMenuOptionData` is directly passed to the SelectMenuBuilder.addOptions method
+ *
+ * `useInSettingsCommand` is whether to use in /settings options
+ *
+ * `menu` is a function that returns an embed of the actual menu
+ * */
 type SettingsMenuOption = {
     /**
      * This is directly passed to the SelectMenuBuilder.addOptions method
      */
-    optionData: SelectMenuComponentOptionData;
+    selectMenuOptionData: SelectMenuComponentOptionData;
+    /**
+     * Whether to use in /settings options
+     * @remark reuses `selectMenuOptionData` to generate the option
+     */
+    useInSettingsCommand: boolean;
     /** A function that returns an embed of the actual menu */
     menu: SettingsMenuConstructor;
 };

--- a/src/utils/util-functions.ts
+++ b/src/utils/util-functions.ts
@@ -10,7 +10,7 @@ import {
     Interaction,
     ModalSubmitInteraction,
     Role,
-    SelectMenuInteraction,
+    StringSelectMenuInteraction,
     TextChannel,
     VoiceChannel,
     VoiceState
@@ -169,7 +169,7 @@ function getInteractionName(interaction: Interaction): string {
     if (interaction.isModalSubmit()) {
         return extractComponentName(interaction.customId, true) ?? 'Modal Submit';
     }
-    if (interaction.isSelectMenu()) {
+    if (interaction.isStringSelectMenu()) {
         return (
             extractComponentName(interaction.customId, true) ??
             interaction.component.placeholder ??
@@ -353,7 +353,7 @@ function logDMModalSubmit(interaction: ModalSubmitInteraction, modalName: string
  * @param selectMenuName
  */
 function logSelectMenuSelection(
-    interaction: SelectMenuInteraction<'cached'>,
+    interaction: StringSelectMenuInteraction<'cached'>,
     selectMenuName: string
 ): void {
     console.log(
@@ -376,7 +376,7 @@ function logSelectMenuSelection(
  * @param selectMenuName
  */
 function logDMSelectMenuSelection(
-    interaction: SelectMenuInteraction,
+    interaction: StringSelectMenuInteraction,
     selectMenuName: string
 ): void {
     console.log(


### PR DESCRIPTION
Updates so far: 
- /queue_notify command added
- Removed the following commands since they have been implemented better via setting menus
    - `/set_after_session_msg`
    - `/set_queue_auto_clear`
    - `/serious_mode`
    - `/auto_give_student_role`
    - `/set_google_sheet`
    - `/set_calendar`
    - `/unset_calendar`
    - `/set_public_embed_url`
- `/settings` now has a `sub_menu_jump` option to allow you to jump to a specific sub menu
- Since `/serious_mode` is removed, #129 is resolved. Instead, a note is added to the serious mode settings sub menu when there are no queues in the server