### PR TITLE
73 auto assign helper queues

### DIFF
--- a/help-channel-messages/AdminCommands.ts
+++ b/help-channel-messages/AdminCommands.ts
@@ -377,6 +377,40 @@ const setRoleHelp: HelpMessage = {
     emoji: '👥'
 };
 
+const assignHelpersRolesHelp: HelpMessage = {
+    nameValuePair: {
+        name: 'assign_helpers_roles',
+        value: 'assign_helpers_roles'
+    },
+    useInHelpChannel: true,
+    useInHelpCommand: true,
+    message: {
+        embeds: [
+            {
+                color: EmbedColor.NoColor,
+                title: 'Command: `/assign_helpers_roles [csv_file]`',
+                fields: [
+                    {
+                        name: 'Description',
+                        value: 'Assigns helpers listed in the csv file to the corresponding queue roles.'
+                    },
+                    {
+                        name: 'Options',
+                        value:
+                            '`csv_file: File`: The csv file containing the data information.' +
+                            'The csv file should be formatted as follows: \n```discord_id,queue_name1, queu_name2\ndiscord_id,queue_name3```\n'
+                    },
+                    {
+                        name: 'Example Usage',
+                        value: '`/assign_helpers_roles helpers.csv`'
+                    }
+                ]
+            }
+        ]
+    },
+    emoji: '🪪'
+};
+
 const adminCommandHelpMessages: HelpMessage[] = [
     adminCommandsTitleMessage,
     queueAddHelp,
@@ -388,7 +422,8 @@ const adminCommandHelpMessages: HelpMessage[] = [
     stopLoggingHelp,
     settingsHelp,
     createOfficesHelp,
-    setRoleHelp
+    setRoleHelp,
+    assignHelpersRolesHelp
 ];
 
 export { adminCommandHelpMessages };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "ascii-table": "^0.0.9",
                 "ascii-table3": "^0.7.7",
                 "axios": "^0.27.2",
+                "csv-string": "^4.1.1",
                 "discord-api": "^0.0.1",
                 "discord-api-types": "^0.37.11",
                 "discord.js": "^14.8.0",
@@ -2075,6 +2076,14 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/csv-string": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+            "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ==",
+            "engines": {
+                "node": ">=12.0"
             }
         },
         "node_modules/debug": {
@@ -8031,6 +8040,11 @@
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
             }
+        },
+        "csv-string": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+            "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ=="
         },
         "debug": {
             "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "ascii-table": "^0.0.9",
         "ascii-table3": "^0.7.7",
         "axios": "^0.27.2",
+        "csv-string": "^4.1.1",
         "discord-api": "^0.0.1",
         "discord-api-types": "^0.37.11",
         "discord.js": "^14.8.0",

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -1036,6 +1036,13 @@ class AttendingServerV2 {
         return true;
     }
 
+    /**
+     * Assigns users to the queue roles based on the data provided. Gives the staff role to the user if they don't have it already.
+     *
+     * **Warning**: Role names in the data array must match the queue names / roles exactly. It is *case sensitive*.
+     * @param helpersRolesData
+     * @returns Log of successfully asssigned roles and errors
+     */
     async assignHelpersRoles(
         helpersRolesData: HelperRolesData[]
     ): Promise<[Map<string, string>, Map<string, string>]> {

--- a/src/attending-server/expected-server-errors.ts
+++ b/src/attending-server/expected-server-errors.ts
@@ -55,6 +55,11 @@ const ExpectedServerErrors = {
         new ServerError(
             "The student you just dequeued did not allow YABOB to send them the invite to your voice channel. Don't worry, they have been successfully dequeued.",
             `ID of the unreachable student: <@${studentThatClosedDm}>`
+        ),
+    memberNotFound: (userId: string) =>
+        new ServerError(
+            `No member with the userId ${userId} was found in this server`,
+            `Please make sure you are using the correct userId.`
         )
 } as const;
 

--- a/src/extensions/google-sheet-logging/interaction-handling/button-handler.ts
+++ b/src/extensions/google-sheet-logging/interaction-handling/button-handler.ts
@@ -35,7 +35,9 @@ async function resetGoogleSheetSettings(
     const state = GoogleSheetExtensionState.get(interaction.guildId);
     await Promise.all([
         state.setGoogleSheet(environment.sessionCalendar.YABOB_DEFAULT_CALENDAR_ID),
-        server.sendLogMessage(GoogleSheetSuccessMessages.updatedGoogleSheet(state.googleSheetURL))
+        server.sendLogMessage(
+            GoogleSheetSuccessMessages.updatedGoogleSheet(state.googleSheetURL)
+        )
     ]);
     await interaction.update(
         GoogleSheetSettingsConfigMenu(

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -681,9 +681,9 @@ async function assignHelpersRoles(
         });
     });
 
-    await server.assignHelpersRoles(helpersRolesData);
+    const roleLogs = await server.assignHelpersRoles(helpersRolesData);
 
-    await interaction.editReply(SuccessMessages.assignedHelpersRoles);
+    await interaction.editReply(SuccessMessages.assignedHelpersRoles(roleLogs));
 }
 
 export { baseYabobCommandMap };

--- a/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
+++ b/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
@@ -310,6 +310,17 @@ const helpCommand = new SlashCommandBuilder()
     .setName(CommandNames.help)
     .setDescription('Get help with the bot');
 
+// /assign_helpers_roles
+const assignHelpersRolesCommand = new SlashCommandBuilder()
+    .setName(CommandNames.assign_helpers_roles)
+    .setDescription('Uses a .csv file to assign roles to all helpers')
+    .addAttachmentOption(option =>
+        option
+            .setName('csv_file')
+            .setDescription('The .csv file to use')
+            .setRequired(true)
+    );
+
 /** The raw data that can be sent to Discord */
 const commandData = [
     queueCommand.toJSON(),
@@ -332,7 +343,8 @@ const commandData = [
     setRolesCommand.toJSON(),
     pauseCommand.toJSON(),
     resumeCommand.toJSON(),
-    helpCommand.toJSON()
+    helpCommand.toJSON(),
+    assignHelpersRolesCommand.toJSON()
 ];
 
 async function postSlashCommands(

--- a/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
+++ b/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
@@ -310,7 +310,7 @@ const helpCommand = new SlashCommandBuilder()
     .setName(CommandNames.help)
     .setDescription('Get help with the bot');
 
-// /assign_helpers_roles
+// /assign_helpers_roles [csv_file]
 const assignHelpersRolesCommand = new SlashCommandBuilder()
     .setName(CommandNames.assign_helpers_roles)
     .setDescription('Uses a .csv file to assign roles to all helpers')

--- a/src/interaction-handling/interaction-constants/expected-interaction-errors.ts
+++ b/src/interaction-handling/interaction-constants/expected-interaction-errors.ts
@@ -126,6 +126,19 @@ includes at least one non-whitespace character.`
     nonExistentTextChannel: (channelId: string | undefined) =>
         new CommandParseError(
             `The channel with id ${channelId} does not exist on this server.`
+        ),
+    invalidContentType: (contentType: string | null) =>
+        new CommandParseError(`The content type ${contentType} is not supported.`),
+    csvParseError: new CommandParseError(
+        'Sorry, I could not parse the CSV file you sent. Please make sure the file is a valid CSV file.'
+    ),
+    invalidDiscordId: (discordId: string | undefined) =>
+        new CommandParseError(
+            `The Discord ID ${discordId} is not a valid Discord ID. Please make sure you are using a valid Discord ID.`
+        ),
+    noQueueNames: (discordId: string) =>
+        new CommandParseError(
+            `The Discord ID ${discordId} does not have any queues associated to them in the .csv.`
         )
 } as const;
 
@@ -145,6 +158,19 @@ const UnexpectedParseErrors = {
                 'Please show this message to a Bot Admin by pinging @Bot Admin (or equivalent).',
             EmbedColor.Error,
             `${err.name}, ${err.message}`
+        ),
+    unexpectedFetchError: (
+        interaction: Interaction,
+        status: number,
+        statusText: string
+    ) =>
+        SimpleEmbed(
+            `An unexpected error happened when fetching data for your interaction \`${getInteractionName(
+                interaction
+            )}\`. ` +
+                'Please show this message to a Bot Admin by pinging @Bot Admin (or equivalent).',
+            EmbedColor.Error,
+            `${status}: ${statusText}`
         )
 } as const;
 

--- a/src/interaction-handling/interaction-constants/interaction-names.ts
+++ b/src/interaction-handling/interaction-constants/interaction-names.ts
@@ -28,7 +28,8 @@ enum CommandNames {
     stop_logging = 'stop_logging',
     create_offices = 'create_offices',
     set_roles = 'set_roles',
-    settings = 'settings'
+    settings = 'settings',
+    assign_helpers_roles = 'assign_helpers_roles'
 }
 
 /**

--- a/src/interaction-handling/interaction-constants/success-messages.ts
+++ b/src/interaction-handling/interaction-constants/success-messages.ts
@@ -155,5 +155,8 @@ export const SuccessMessages = {
     turnedOffPromptHelpTopic: SimpleEmbed(
         `Successfully turned off prompt help topic. YABOB will no longer prompt students to select a help topic when they join a queue.`,
         EmbedColor.Success
+    ),
+    assignedHelpersRoles: SimpleEmbed(
+        `Successfully assigned the respective queue roles to all the helpers`
     )
 } as const;

--- a/src/interaction-handling/interaction-constants/success-messages.ts
+++ b/src/interaction-handling/interaction-constants/success-messages.ts
@@ -158,8 +158,14 @@ export const SuccessMessages = {
     ),
     assignedHelpersRoles: (roleLogs: string) =>
         SimpleEmbed(
-            `Successfully assigned the respective queue roles to all the helpers`,
+            `Successfully assigned the respective queue roles to the helpers`,
             EmbedColor.Success,
+            roleLogs
+        ),
+    partiallyAssignedHelpersRoles: (roleLogs: string) =>
+        SimpleEmbed(
+            `There were some errors assigning the respective queue roles to the helpers. Please check the logs below.`,
+            EmbedColor.KindaBad,
             roleLogs
         )
 } as const;

--- a/src/interaction-handling/interaction-constants/success-messages.ts
+++ b/src/interaction-handling/interaction-constants/success-messages.ts
@@ -156,7 +156,9 @@ export const SuccessMessages = {
         `Successfully turned off prompt help topic. YABOB will no longer prompt students to select a help topic when they join a queue.`,
         EmbedColor.Success
     ),
-    assignedHelpersRoles: SimpleEmbed(
-        `Successfully assigned the respective queue roles to all the helpers`
+    assignedHelpersRoles: (roleLogs: string) => SimpleEmbed(
+        `Successfully assigned the respective queue roles to all the helpers`,
+        EmbedColor.Success,
+        roleLogs
     )
 } as const;

--- a/src/interaction-handling/interaction-constants/success-messages.ts
+++ b/src/interaction-handling/interaction-constants/success-messages.ts
@@ -156,9 +156,10 @@ export const SuccessMessages = {
         `Successfully turned off prompt help topic. YABOB will no longer prompt students to select a help topic when they join a queue.`,
         EmbedColor.Success
     ),
-    assignedHelpersRoles: (roleLogs: string) => SimpleEmbed(
-        `Successfully assigned the respective queue roles to all the helpers`,
-        EmbedColor.Success,
-        roleLogs
-    )
+    assignedHelpersRoles: (roleLogs: string) =>
+        SimpleEmbed(
+            `Successfully assigned the respective queue roles to all the helpers`,
+            EmbedColor.Success,
+            roleLogs
+        )
 } as const;

--- a/src/utils/type-aliases.ts
+++ b/src/utils/type-aliases.ts
@@ -176,6 +176,13 @@ type SettingsMenuOption = {
 /** Type alias for interaction extensions */
 type CommandData = ReadonlyArray<RESTPostAPIChatInputApplicationCommandsJSONBody>;
 
+type HelperRolesData = {
+    /** The user id of the helper */
+    helperId: GuildMemberId;
+    /** Thbe queues for which the helper is assigned */
+    queues: string[];
+};
+
 export {
     /** Types */
     WithRequired,
@@ -194,6 +201,7 @@ export {
     EnsureCorrectEnum,
     SettingsMenuOption,
     CommandData,
+    HelperRolesData,
     /** Aliases */
     GuildId,
     GuildMemberId,


### PR DESCRIPTION
Added `/assign_helpers_roles [csv_file]` command

- csv file must be in the following format
```csv
discord_id1,queue_name1,queue_name2
discord_id2,queue_name1,queue_name2,queue_name3
discord_id3,queue_name4
...
```

- The queue names checks are case sensitive
- Gives the user the Staff role if they don't have it already
- Does not remove the staff role from users not in this list
- Success Message provides logs of the changes and errors