### PR TITLE
Use Global Slash Commands instead of Guild-specific commands

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ import { environment } from './environment/environment-manager.js';
 import { updatePresence } from './utils/discord-presence.js';
 import { printTitleString, isLeaveVC, isJoinVC } from './utils/util-functions.js';
 import { serverSettingsMainMenuOptions } from './attending-server/server-settings-menus.js';
-import { postSlashCommands } from './interaction-handling/interaction-constants/builtin-slash-commands.js';
+import { postGuildSlashCommands, postGlobalSlashCommands } from './interaction-handling/interaction-constants/builtin-slash-commands.js';
 import { UnexpectedParseErrors } from './interaction-handling/interaction-constants/expected-interaction-errors.js';
 import { adminCommandHelpMessages } from '../help-channel-messages/AdminCommands.js';
 import { helperCommandHelpMessages } from '../help-channel-messages/HelperCommands.js';
@@ -44,6 +44,17 @@ client.on(Events.ClientReady, async () => {
     LOGGER.info('-------- Begin Server Logs --------');
     updatePresence();
     setInterval(updatePresence, 1000 * 60 * 30);
+    if(environment.env === 'production') {
+        const externalCommandData = environment.disableExtensions
+            ? []
+            : interactionExtensions.flatMap(ext => ext.slashCommandData);
+        await postGlobalSlashCommands(externalCommandData);
+    }
+    else
+    {
+        // remove global commands during development
+        await client.application.commands.set([]);
+    }
 });
 
 /**
@@ -201,10 +212,16 @@ process.on('exit', () => {
  */
 async function joinGuild(guild: Guild): Promise<AttendingServerV2> {
     LOGGER.info(`Joining guild: ${yellow(guild.name)}`);
-    const externalCommandData = environment.disableExtensions
-        ? []
-        : interactionExtensions.flatMap(ext => ext.slashCommandData);
-    await postSlashCommands(guild, externalCommandData);
+    if(environment.env === 'development') {
+        const externalCommandData = environment.disableExtensions
+            ? []
+            : interactionExtensions.flatMap(ext => ext.slashCommandData);
+        await postGuildSlashCommands(guild, externalCommandData);
+    }
+    else { // production
+        // clear all guild commands
+        await guild.commands.set([]);
+    }
     await guild.commands.fetch(); // populate cache
     // Extensions for server & queue are loaded inside the create method
     const server = await AttendingServerV2.create(guild);

--- a/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
+++ b/src/interaction-handling/interaction-constants/builtin-slash-commands.ts
@@ -414,7 +414,7 @@ const commandData = [
     createHelperControlPanelCommand.toJSON()
 ];
 
-async function postSlashCommands(
+async function postGuildSlashCommands(
     guild: Guild,
     externalCommands: CommandData = []
 ): Promise<void> {
@@ -445,4 +445,23 @@ async function postSlashCommands(
     LOGGER.info(`✓ Updated slash commands on '${guild.name}' ✓`);
 }
 
-export { postSlashCommands };
+async function postGlobalSlashCommands(
+    externalCommands: CommandData = []
+): Promise<void> {
+    if (environment.discordBotCredentials.YABOB_APP_ID.length === 0) {
+        throw new Error('Failed to post commands. APP_ID is undefined');
+    }
+    if (environment.discordBotCredentials.YABOB_BOT_TOKEN.length === 0) {
+        throw new Error('Failed to post commands. BOT_TOKEN is undefined');
+    }
+    const rest = new REST().setToken(environment.discordBotCredentials.YABOB_BOT_TOKEN);
+    await rest
+        .put(Routes.applicationCommands(environment.discordBotCredentials.YABOB_APP_ID), {
+            // need to call generateHelpCommand() here because it needs to be called after the external help messages are added
+            body: commandData.concat(externalCommands, generateSettingsCommand().toJSON())
+        })
+        .catch(err => CALENDAR_LOGGER.error(err, `Failed to post slash command to`));
+    LOGGER.info(`✓ Updated slash commands ✓`);
+}
+
+export { postGuildSlashCommands, postGlobalSlashCommands };


### PR DESCRIPTION
Not really sure what benefits are there apart from the nice slash command badge on the bot, I'm guessing it's probably some server optimization

This is only for prod since it takes ~1 hour to update. Dev still use guild commands since they update instantly

Currently breaks querying of the command's snowflake id