### PR TITLE
213 remove `queueChannelsCache` and other refactoring changes

### DIFF
--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -302,14 +302,14 @@ class AttendingServer {
             server.loadBackup(externalBackup);
         }
 
-        const missingRoles = server.sortedAccessLevelRoles.filter(
+        const accessLevelRolesAreMissing = server.sortedAccessLevelRoles.some(
             role =>
                 role.id === SpecialRoleValues.NotSet ||
                 role.id === SpecialRoleValues.Deleted ||
                 !guild.roles.cache.has(role.id)
         );
 
-        if (missingRoles.length > 0) {
+        if (accessLevelRolesAreMissing) {
             guild
                 .fetchOwner()
                 .then(owner => owner.send(RoleConfigMenuForServerInit(server, false)))
@@ -1105,11 +1105,7 @@ class AttendingServer {
      */
     @useSettingsBackup
     async setSeriousServer(enable: boolean): Promise<void> {
-        const setting = HelpQueue.sharedSettings.get(this.guildId);
-        if (setting) {
-            setting.seriousModeEnabled = enable;
-            await Promise.all(this._queues.map(queue => queue.triggerRender()));
-        }
+        this._queues.forEach(queue => queue.setSeriousMode(enable));
     }
 
     @useSettingsBackup

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -1125,7 +1125,7 @@ class AttendingServer {
      */
     async assignHelpersRoles(
         helpersRolesData: HelperRolesData[]
-    ): Promise<[Map<string, string>, Map<string, string>]> {
+    ): Promise<[logMap: Map<string, string>, errorMap: Map<string, string>]> {
         // for each helper id in helpersRolesData, remove preexisting queue roles and assign the queues roles using the queue name listed in the data array
         const queueNames = this.queues.map(queue => queue.queueName);
         // ensure the queue roles exist so that queueRoles is guaranteed to not contain undefined

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -570,33 +570,33 @@ class AttendingServer {
      */
     async updateQueueName(oldCategory: CategoryChannel, newCategory: CategoryChannel) {
         const newName = newCategory.name;
-        const queue = this._queues.get(oldCategory.id);
+        const queueToRename = this._queues.get(oldCategory.id);
 
-        if (!queue) {
+        if (!queueToRename) {
             return;
         }
 
         const role = this.guild.roles.cache.find(role => role.name === oldCategory.name);
         const newQueueChannel: QueueChannel = {
-            textChannel: queue.queueChannel.textChannel,
-            queueName: newName,
-            parentCategoryId: queue.parentCategoryId
+            ...queueToRename.queueChannel,
+            queueName: newName
         };
-        const nameTaken = this._queues.some(
-            queue => queue.queueName === newName && queue !== queue
+        // TODO: this doesn't seem necessary
+        const queueNameTaken = this._queues.some(
+            queue => queue.queueName === newName
         );
-        const roleTaken = this.guild.roles.cache.some(
+        const roleNameTaken = this.guild.roles.cache.some(
             role => role.name === newCategory.name
         );
 
-        if (nameTaken) {
+        if (queueNameTaken) {
             throw ExpectedServerErrors.queueAlreadyExists(newName);
         }
-        if (role && !roleTaken) {
+        if (role && !roleNameTaken) {
             await role.setName(newName);
         }
 
-        await queue.updateQueueChannel(newQueueChannel);
+        await queueToRename.updateQueueChannel(newQueueChannel);
     }
 
     /**

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -569,7 +569,6 @@ class AttendingServer {
      * @param newCategory New category channel after the name was updated
      */
     async updateQueueName(oldCategory: CategoryChannel, newCategory: CategoryChannel) {
-        const oldName = oldCategory.name;
         const newName = newCategory.name;
         const queue = this._queues.get(oldCategory.id);
 
@@ -591,11 +590,7 @@ class AttendingServer {
         );
 
         if (nameTaken) {
-            await newCategory.setName(oldName);
-            LOGGER.error(
-                `Queue name '${newName}' already exists. Rename '${oldName}' to a different name.`
-            );
-            return;
+            throw ExpectedServerErrors.queueAlreadyExists(newName);
         }
         if (role && !roleTaken) {
             await role.setName(newName);

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -105,18 +105,17 @@ class AttendingServer {
      * without passing through a interaction handler first
      * - equivalent to the old attendingServers global object
      */
-    private static readonly allServers: Collection<GuildId, AttendingServer> =
-        new Collection();
+    private static readonly allServers = new Collection<GuildId, AttendingServer>();
     /**
      * Unique helpers (both active and paused)
      * - Key is GuildMember.id
      */
-    private _helpers: Collection<GuildMemberId, Helper> = new Collection();
+    private _helpers = new Collection<GuildMemberId, Helper>();
     /**
      * All the queues of this server
      * - Key is CategoryChannel.id of the parent category of #queue
      */
-    private _queues: Collection<CategoryChannelId, HelpQueue> = new Collection();
+    private _queues = new Collection<CategoryChannelId, HelpQueue>();
     /**
      * Cached result of {@link getQueueChannels}
      */
@@ -145,7 +144,7 @@ class AttendingServer {
 
     protected constructor(
         readonly guild: Guild,
-        readonly serverExtensions: ReadonlyArray<ServerExtension>
+        readonly serverExtensions: readonly ServerExtension[]
     ) {
         this.logger = LOGGER.child({ guild: this.guild.name });
     }
@@ -224,12 +223,12 @@ class AttendingServer {
     }
 
     /** List of category channel IDs on this server */
-    get categoryChannelIDs(): ReadonlyArray<CategoryChannelId> {
+    get categoryChannelIDs(): readonly CategoryChannelId[] {
         return [...this._queues.keys()];
     }
 
     /** List of queues on this server */
-    get queues(): ReadonlyArray<HelpQueue> {
+    get queues(): readonly HelpQueue[] {
         return [...this._queues.values()];
     }
 

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -613,8 +613,8 @@ class AttendingServer {
             await role.setName(newName);
         }
 
-        queue.queueChannel = newQueueChannel;
-        await queue.triggerRender();
+        await queue.updateQueueChannel(newQueueChannel);
+
         await Promise.all(
             this.serverExtensions.map(extension =>
                 extension.onQueueChannelUpdate(this, oldName, newQueueChannel)

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -581,7 +581,6 @@ class AttendingServer {
             ...queueToRename.queueChannel,
             queueName: newName
         };
-        // TODO: this doesn't seem necessary
         const queueNameTaken = this._queues.some(
             queue => queue.queueName === newName
         );

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -1102,7 +1102,7 @@ class AttendingServer {
      * @param sheetTracking
      */
     @useSettingsBackup
-    async setSheetTracking(sheetTracking: boolean): Promise<void> {
+    setSheetTracking(sheetTracking: boolean): void {
         this.settings.sheetTracking = sheetTracking;
     }
 

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -117,10 +117,6 @@ class AttendingServer {
      */
     private _queues = new Collection<CategoryChannelId, HelpQueue>();
     /**
-     * Cached result of {@link getQueueChannels}
-     */
-    private queueChannelsCache: QueueChannel[] = [];
-    /**
      * Server settings. An firebase update is requested as soon as this changes
      */
     private settings: ServerSettings = {
@@ -569,19 +565,19 @@ class AttendingServer {
 
     /**
      * Updates the queue name for queue embeds, roles, and calendar extension
-     * @param oldChannel Old category channel before the name was updated
-     * @param newChannel New category channel after the name was updated
+     * @param oldCategory Old category channel before the name was updated
+     * @param newCategory New category channel after the name was updated
      */
-    async updateQueueName(oldChannel: CategoryChannel, newChannel: CategoryChannel) {
-        const oldName = oldChannel.name;
-        const newName = newChannel.name;
-        const queue = this._queues.get(oldChannel.id);
+    async updateQueueName(oldCategory: CategoryChannel, newCategory: CategoryChannel) {
+        const oldName = oldCategory.name;
+        const newName = newCategory.name;
+        const queue = this._queues.get(oldCategory.id);
 
         if (!queue) {
             return;
         }
 
-        const role = this.guild.roles.cache.find(role => role.name === oldChannel.name);
+        const role = this.guild.roles.cache.find(role => role.name === oldCategory.name);
         const newQueueChannel: QueueChannel = {
             textChannel: queue.queueChannel.textChannel,
             queueName: newName,
@@ -591,18 +587,11 @@ class AttendingServer {
             queue => queue.queueName === newName && queue !== queue
         );
         const roleTaken = this.guild.roles.cache.some(
-            role => role.name === newChannel.name
-        );
-        const cachedChannelIndex = this.queueChannelsCache.findIndex(
-            queueChannel => queueChannel.queueName === oldName
+            role => role.name === newCategory.name
         );
 
-        if (cachedChannelIndex !== -1) {
-            this.queueChannelsCache.splice(cachedChannelIndex, 1);
-            this.queueChannelsCache.push(newQueueChannel);
-        }
         if (nameTaken) {
-            await newChannel.setName(oldName);
+            await newCategory.setName(oldName);
             LOGGER.error(
                 `Queue name '${newName}' already exists. Rename '${oldName}' to a different name.`
             );

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -219,7 +219,7 @@ class AttendingServer {
         return this._queues.first()?.timeUntilAutoClear;
     }
 
-    get queueChannels(): readonly QueueChannel[]{
+    get queueChannels(): readonly QueueChannel[] {
         return this._queues.map(queue => queue.queueChannel);
     }
 
@@ -1253,16 +1253,14 @@ class AttendingServer {
 
         // for each queueName, if it's not in existingRoles, create it
         await Promise.all(
-            queueChannels.value
-                .map(channel => channel.queueName)
-                .map(async roleToCreate => {
-                    if (!existingRoles.has(roleToCreate)) {
-                        await this.guild.roles.create({
-                            name: roleToCreate,
-                            position: 1
-                        });
-                    }
-                })
+            queueChannels.value.map(async channel => {
+                if (!existingRoles.has(channel.queueName)) {
+                    await this.guild.roles.create({
+                        name: channel.queueName,
+                        position: 1
+                    });
+                }
+            })
         );
     }
 

--- a/src/attending-server/base-attending-server.ts
+++ b/src/attending-server/base-attending-server.ts
@@ -602,12 +602,6 @@ class AttendingServer {
         }
 
         await queue.updateQueueChannel(newQueueChannel);
-
-        await Promise.all(
-            this.serverExtensions.map(extension =>
-                extension.onQueueChannelUpdate(this, oldName, newQueueChannel)
-            )
-        );
     }
 
     /**

--- a/src/attending-server/firebase-backup.ts
+++ b/src/attending-server/firebase-backup.ts
@@ -159,7 +159,7 @@ function backupQueueData(queue: HelpQueue): void {
     };
     const firebaseDoc = firebaseDB
         .collection('serverBackups')
-        .doc(queue.queueChannel.channelObj.guild.id);
+        .doc(queue.queueChannel.textChannel.guild.id);
     // we are assuming the doc exists, since it's impossible to have a queue method call without a queue
     firebaseDoc
         .get()
@@ -177,7 +177,7 @@ function backupQueueData(queue: HelpQueue): void {
                 })
                 .then(() =>
                     LOGGER.info(
-                        queue.channelObject.guild.name,
+                        queue.textChannelect.guild.name,
                         '- Queue backup successful'
                     )
                 )

--- a/src/attending-server/firebase-backup.ts
+++ b/src/attending-server/firebase-backup.ts
@@ -177,7 +177,7 @@ function backupQueueData(queue: HelpQueue): void {
                 })
                 .then(() =>
                     LOGGER.info(
-                        queue.textChannelect.guild.name,
+                        queue.textChannel.guild.name,
                         '- Queue backup successful'
                     )
                 )

--- a/src/extensions/extension-interface.ts
+++ b/src/extensions/extension-interface.ts
@@ -8,7 +8,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { GuildMember, VoiceChannel } from 'discord.js';
+import { GuildMember, TextChannel, VoiceChannel } from 'discord.js';
 import { HelpQueue } from '../help-queue/help-queue.js';
 import { Helpee, Helper } from '../models/member-states.js';
 import { ServerBackup } from '../models/backups.js';
@@ -162,18 +162,6 @@ interface ServerExtension {
      * @param server the server to backup
      */
     onServerRequestBackup: (server: FrozenServer) => Promise<void>;
-    /**
-     * When a queue category channel is updated
-     * @param server the server of the category queue
-     * @param oldName old name of queue category channel
-     * @param newChannel new queue category channel object
-     * @returns
-     */
-    onQueueChannelUpdate: (
-        server: FrozenServer,
-        oldName: string,
-        newChannel: QueueChannel
-    ) => Promise<void>;
 }
 
 /** Extensions for individual queues */
@@ -219,6 +207,18 @@ interface QueueExtension {
     onRemoveAllStudents: (
         queue: FrozenQueue,
         students: ReadonlyArray<Helpee>
+    ) => Promise<void>;
+    /**
+     * When the category channel of this queue is changed (mostly name changes)
+     * @param queue
+     * @param oldQueueChannel
+     * @param newQueueChannel
+     * @returns
+     */
+    onQueueChannelUpdate: (
+        queue: FrozenQueue,
+        oldQueueChannel: QueueChannel,
+        newQueueChannel: QueueChannel
     ) => Promise<void>;
     /**
      * When a queue re-render happens
@@ -346,13 +346,6 @@ abstract class BaseServerExtension implements ServerExtension {
     onServerRequestBackup(server: FrozenServer): Promise<void> {
         return Promise.resolve();
     }
-    onQueueChannelUpdate(
-        server: FrozenServer,
-        oldName: string,
-        newChannel: QueueChannel
-    ): Promise<void> {
-        return Promise.resolve();
-    }
 }
 
 /**
@@ -386,6 +379,13 @@ abstract class BaseQueueExtension implements QueueExtension {
     onRemoveAllStudents(
         queue: FrozenQueue,
         students: ReadonlyArray<Helpee>
+    ): Promise<void> {
+        return Promise.resolve();
+    }
+    onQueueChannelUpdate(
+        queue: FrozenQueue,
+        oldQueueChannel: QueueChannel,
+        newQueueChannel: QueueChannel
     ): Promise<void> {
         return Promise.resolve();
     }

--- a/src/extensions/extension-interface.ts
+++ b/src/extensions/extension-interface.ts
@@ -26,7 +26,7 @@ import {
     SelectMenuHandlerProps
 } from '../interaction-handling/handler-interface.js';
 import { CommandData } from '../utils/type-aliases.js';
-import { QueueChannel } from '../attending-server/base-attending-server.js';
+import { QueueChannel } from '../models/queue-channel.js';
 
 interface InteractionExtension {
     /**

--- a/src/extensions/extension-utils.ts
+++ b/src/extensions/extension-utils.ts
@@ -15,7 +15,7 @@ type FrozenQueue = Omit<ConstNoMethod<HelpQueue>, 'timers'>;
  * - sendLogMessage
  */
 type FrozenServer = ConstNoMethod<AttendingServer> &
-    Pick<AttendingServer, 'getQueueChannels' | 'sendLogMessage'>;
+    Pick<AttendingServer, 'queueChannels' | 'sendLogMessage'>;
 
 /**
  * Only exposes the requestExtensionEmbedRender method for extensions

--- a/src/extensions/google-sheet-logging/google-sheet-server-extension.ts
+++ b/src/extensions/google-sheet-logging/google-sheet-server-extension.ts
@@ -53,7 +53,7 @@ class GoogleSheetServerExtension extends BaseServerExtension implements ServerEx
      * Used to compose the final attendance entry.
      * - Key is helper member.id, value is entry for this helper
      */
-    private activeTimeEntries: Collection<GuildMemberId, ActiveTime> = new Collection();
+    private activeTimeEntries = new Collection<GuildMemberId, ActiveTime>();
     /**
      * These are the attendance entries that are complete but haven't been sent to google sheets yet
      * - Cleared immediately after google sheet has been successfully updated
@@ -68,13 +68,12 @@ class GoogleSheetServerExtension extends BaseServerExtension implements ServerEx
      * Current active help session entries of each student
      * - key is student member.id, value is an array of entries to handle multiple helpers
      */
-    private helpSessionEntries: Collection<GuildMemberId, HelpSessionEntry[]> =
-        new Collection();
+    private helpSessionEntries = new Collection<GuildMemberId, HelpSessionEntry[]>();
     /**
      * Students that just got dequeued but haven't joined the VC yet
      * - Key is student member.id, value is corresponding helpee object
      */
-    private studentsJustDequeued: Collection<GuildMemberId, Helpee> = new Collection();
+    private studentsJustDequeued = new Collection<GuildMemberId, Helpee>();
 
     private logger: Logger;
 

--- a/src/extensions/google-sheet-logging/interaction-handling/button-handler.ts
+++ b/src/extensions/google-sheet-logging/interaction-handling/button-handler.ts
@@ -35,7 +35,7 @@ async function updateSheetTrackingStatus(
 ): Promise<void> {
     const server = AttendingServer.get(interaction.guildId);
     const newTrackingStatus = !server.sheetTracking;
-    
+
     await Promise.all([
         server.setSheetTracking(newTrackingStatus),
         server.sendLogMessage(
@@ -62,7 +62,7 @@ async function resetGoogleSheetSettings(
 ): Promise<void> {
     const server = AttendingServer.get(interaction.guildId);
     const state = GoogleSheetExtensionState.get(interaction.guildId);
-    
+
     await Promise.all([
         state.setGoogleSheet(environment.googleSheetLogging.YABOB_GOOGLE_SHEET_ID),
         server.setSheetTracking(false),

--- a/src/extensions/google-sheet-logging/interaction-handling/button-handler.ts
+++ b/src/extensions/google-sheet-logging/interaction-handling/button-handler.ts
@@ -36,12 +36,11 @@ async function updateSheetTrackingStatus(
     const server = AttendingServer.get(interaction.guildId);
     const newTrackingStatus = !server.sheetTracking;
 
-    await Promise.all([
-        server.setSheetTracking(newTrackingStatus),
-        server.sendLogMessage(
-            GoogleSheetSuccessMessages.updatedSheetTracking(newTrackingStatus)
-        )
-    ]);
+    server.setSheetTracking(newTrackingStatus);
+    server.sendLogMessage(
+        GoogleSheetSuccessMessages.updatedSheetTracking(newTrackingStatus)
+    );
+
     await interaction.update(
         GoogleSheetSettingsConfigMenu(
             server,
@@ -63,13 +62,12 @@ async function resetGoogleSheetSettings(
     const server = AttendingServer.get(interaction.guildId);
     const state = GoogleSheetExtensionState.get(interaction.guildId);
 
-    await Promise.all([
-        state.setGoogleSheet(environment.googleSheetLogging.YABOB_GOOGLE_SHEET_ID),
-        server.setSheetTracking(false),
-        server.sendLogMessage(
-            GoogleSheetSuccessMessages.updatedGoogleSheet(state.googleSheetURL)
-        )
-    ]);
+    await state.setGoogleSheet(environment.googleSheetLogging.YABOB_GOOGLE_SHEET_ID);
+   
+    server.setSheetTracking(false);
+    server.sendLogMessage(
+        GoogleSheetSuccessMessages.updatedGoogleSheet(state.googleSheetURL)
+    );
 
     await interaction.update(
         GoogleSheetSettingsConfigMenu(

--- a/src/extensions/google-sheet-logging/interaction-handling/modal-handler.ts
+++ b/src/extensions/google-sheet-logging/interaction-handling/modal-handler.ts
@@ -45,7 +45,7 @@ async function updateGoogleSheetSettings(
     await state.setGoogleSheet(googleSheetID);
     // Enable tracking when new sheet is not default sheet
     if (googleSheetID !== environment.googleSheetLogging.YABOB_GOOGLE_SHEET_ID) {
-        await server.setSheetTracking(true);
+        server.setSheetTracking(true);
     }
 
     server.sendLogMessage(

--- a/src/extensions/session-calendar/calendar-queue-extension.ts
+++ b/src/extensions/session-calendar/calendar-queue-extension.ts
@@ -2,7 +2,7 @@
 import { BaseQueueExtension } from '../extension-interface.js';
 import { EmbedColor } from '../../utils/embed-helper.js';
 import { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
-import { QueueChannel } from '../../attending-server/base-attending-server.js';
+import { QueueChannel } from '../../models/queue-channel.js';
 import {
     buildUpcomingSessionsEmbedBody,
     restorePublicEmbedURL
@@ -45,7 +45,7 @@ class CalendarQueueExtension extends BaseQueueExtension {
         queueChannel: QueueChannel,
         display: FrozenDisplay
     ): Promise<CalendarQueueExtension> {
-        const state = CalendarExtensionState.get(queueChannel.channelObj.guild.id);
+        const state = CalendarExtensionState.get(queueChannel.textChannel.guild.id);
         const instance = new CalendarQueueExtension(renderIndex, queueChannel, display);
         state.queueExtensions.set(queueChannel.queueName, instance);
         return instance;
@@ -72,7 +72,7 @@ class CalendarQueueExtension extends BaseQueueExtension {
      */
     override async onQueueDelete(deletedQueue: FrozenQueue): Promise<void> {
         CalendarExtensionState.get(
-            this.queueChannel.channelObj.guild.id
+            this.queueChannel.textChannel.guild.id
         ).queueExtensions.delete(deletedQueue.queueName);
     }
 
@@ -81,7 +81,7 @@ class CalendarQueueExtension extends BaseQueueExtension {
      * @param refreshCache whether to refresh the upcomingSessions cache
      */
     private renderCalendarEmbeds(): void {
-        const state = CalendarExtensionState.get(this.queueChannel.channelObj.guild.id);
+        const state = CalendarExtensionState.get(this.queueChannel.textChannel.guild.id);
         const queueName = this.queueChannel.queueName;
         const upcomingSessionsEmbed = new EmbedBuilder()
             .setTitle(`Upcoming Sessions for ${queueName}`)
@@ -112,7 +112,7 @@ class CalendarQueueExtension extends BaseQueueExtension {
             buildComponent(new ButtonBuilder(), [
                 'queue',
                 CalendarButtonNames.Refresh,
-                this.queueChannel.channelObj.guildId
+                this.queueChannel.textChannel.guildId
             ])
                 .setEmoji('🔄')
                 .setLabel('Refresh Upcoming Sessions')

--- a/src/extensions/session-calendar/calendar-server-extension.ts
+++ b/src/extensions/session-calendar/calendar-server-extension.ts
@@ -3,7 +3,6 @@ import { BaseServerExtension } from '../extension-interface.js';
 import { FrozenServer } from '../extension-utils.js';
 import { CalendarExtensionState } from './calendar-states.js';
 import { CALENDAR_LOGGER } from './shared-calendar-functions.js';
-import { QueueChannel } from '../../models/queue-channel.js';
 
 /**
  * Server extension of session calendar
@@ -50,21 +49,6 @@ class CalendarServerExtension extends BaseServerExtension {
         // otherwise the timer arrow func will still hold the reference to the deleted instance
         clearInterval(this.timerId);
         CalendarExtensionState.allStates.delete(server.guild.id);
-    }
-
-    /**
-     * If a queue channel name is changed on discord, update the calendar name
-     * @param server the server of the changed queue channel
-     * @param oldName new name of queue channel
-     * @param newChannel new queue channel object
-     */
-    override async onQueueChannelUpdate(
-        server: FrozenServer,
-        oldName: string,
-        newChannel: QueueChannel
-    ): Promise<void> {
-        const state = CalendarExtensionState.get(server.guild.id);
-        await state.renameCalendar(oldName, newChannel);
     }
 }
 

--- a/src/extensions/session-calendar/calendar-server-extension.ts
+++ b/src/extensions/session-calendar/calendar-server-extension.ts
@@ -3,7 +3,7 @@ import { BaseServerExtension } from '../extension-interface.js';
 import { FrozenServer } from '../extension-utils.js';
 import { CalendarExtensionState } from './calendar-states.js';
 import { CALENDAR_LOGGER } from './shared-calendar-functions.js';
-import { QueueChannel } from '../../attending-server/base-attending-server.js';
+import { QueueChannel } from '../../models/queue-channel.js';
 
 /**
  * Server extension of session calendar

--- a/src/extensions/session-calendar/calendar-states.ts
+++ b/src/extensions/session-calendar/calendar-states.ts
@@ -17,7 +17,6 @@ import { z } from 'zod';
 import { CalendarServerExtension } from './calendar-server-extension.js';
 import { ExpectedCalendarErrors } from './calendar-constants/expected-calendar-errors.js';
 import { ServerExtension } from '../extension-interface.js';
-import { QueueChannel } from '../../models/queue-channel.js';
 import { Logger } from 'pino';
 
 /**
@@ -233,23 +232,6 @@ class CalendarExtensionState {
         }
         this.backupToFirebase();
         await this.emitStateChangeEvent();
-    }
-
-    /**
-     * Resets the name of the queue extension
-     * change the key(queue channel name) that maps to the value (queue extension object)
-     * @param oldName
-     * @param newQueueChannel
-     */
-    async renameCalendar(oldName: string, newQueueChannel: QueueChannel) {
-        const newName = newQueueChannel.queueName;
-        const queueExtension = this.queueExtensions.get(oldName);
-        if (queueExtension) {
-            this.queueExtensions.set(newName, queueExtension);
-            this.queueExtensions.delete(oldName);
-            queueExtension.queueChannel = newQueueChannel;
-            await this.emitStateChangeEvent();
-        }
     }
 
     /**

--- a/src/extensions/session-calendar/calendar-states.ts
+++ b/src/extensions/session-calendar/calendar-states.ts
@@ -67,7 +67,7 @@ class CalendarExtensionState {
      * Save the data from /make_calendar_string,
      * - key is calendar display name, value is discord id
      */
-    calendarNameDiscordIdMap: LRU<string, GuildMemberId> = new LRU({ max: 100 });
+    calendarNameDiscordIdMap = new LRU<string, GuildMemberId>({ max: 100 });
     /**
      * When was the upcomingSessions cache last updated
      */
@@ -80,7 +80,7 @@ class CalendarExtensionState {
      * Corresponding queue extensions, their onCalendarStateChange will be called
      * - key is queue name
      */
-    queueExtensions: Collection<string, CalendarQueueExtension> = new Collection();
+    queueExtensions = new Collection<string, CalendarQueueExtension>();
     /**
      * All upcoming sessions of this server
      */

--- a/src/extensions/session-calendar/calendar-states.ts
+++ b/src/extensions/session-calendar/calendar-states.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import { CalendarServerExtension } from './calendar-server-extension.js';
 import { ExpectedCalendarErrors } from './calendar-constants/expected-calendar-errors.js';
 import { ServerExtension } from '../extension-interface.js';
-import { QueueChannel } from '../../attending-server/base-attending-server.js';
+import { QueueChannel } from '../../models/queue-channel.js';
 import { Logger } from 'pino';
 
 /**

--- a/src/extensions/session-calendar/calendar-states.ts
+++ b/src/extensions/session-calendar/calendar-states.ts
@@ -183,7 +183,7 @@ class CalendarExtensionState {
         if (this.publicCalendarEmbedUrl.length === 0) {
             this.publicCalendarEmbedUrl = restorePublicEmbedURL(this.calendarId);
         }
-        
+
         this.calendarNameDiscordIdMap.load(
             Object.entries(calendarBackup.data.calendarNameDiscordIdMap).map(
                 ([key, value]) => [key, { value: value }]

--- a/src/extensions/session-calendar/shared-calendar-functions.ts
+++ b/src/extensions/session-calendar/shared-calendar-functions.ts
@@ -146,11 +146,11 @@ function buildUpcomingSessionsEmbedBody(
     const lastUpdatedTimeStampString = `${divider}Last updated: <t:${Math.floor(
         lastUpdatedTimeStamp.getTime() / 1000
     )}:R>`;
-    
+
     if (viewModels.length === 0) {
         return `**There are no upcoming sessions for ${title} in the next 7 days.**${lastUpdatedTimeStampString}`;
     }
-    
+
     if (returnCount === 'max') {
         let currLength = lastUpdatedTimeStampString.length; // current embed message length
         const upcomingSessionStrings: string[] = [];

--- a/src/help-queue/help-queue.ts
+++ b/src/help-queue/help-queue.ts
@@ -75,12 +75,12 @@ class HelpQueue {
      * Set of active helpers' ids
      * - This is synchronized with the helpers that are marked 'active' in AttendingServerV2
      */
-    private _activeHelperIds: Set<Snowflake> = new Set();
+    private _activeHelperIds = new Set<Snowflake>();
     /**
      * Set of helpers ids that have paused helping
      * - This is synchronized with the helpers that are marked 'paused' in AttendingServerV2
      */
-    private _pausedHelperIds: Set<Snowflake> = new Set();
+    private _pausedHelperIds = new Set<Snowflake>();
     /**
      * The actual queue of students
      */
@@ -103,7 +103,7 @@ class HelpQueue {
      * @param backupData if defined, use this data to restore the students array
      */
     protected constructor(
-        public queueChannel: Readonly<QueueChannel>,
+        private _queueChannel: Readonly<QueueChannel>,
         private readonly queueExtensions: QueueExtension[],
         private readonly display: QueueDisplay,
         backupData?: QueueBackup
@@ -127,6 +127,10 @@ class HelpQueue {
                 });
             }
         }
+    }
+
+    get queueChannel(): QueueChannel {
+        return this._queueChannel;
     }
 
     /** Set of helper IDs. Enforce readonly */
@@ -193,7 +197,7 @@ class HelpQueue {
     }
 
     /** All students */
-    get students(): ReadonlyArray<Helpee> {
+    get students(): readonly Helpee[] {
         return this._students;
     }
 
@@ -674,6 +678,11 @@ class HelpQueue {
         ]);
 
         return removedStudent;
+    }
+
+    async updateQueueChannel(newChannel: QueueChannel): Promise<void> {
+        this._queueChannel = newChannel;
+        await this.triggerRender();
     }
 
     /**

--- a/src/help-queue/help-queue.ts
+++ b/src/help-queue/help-queue.ts
@@ -203,7 +203,7 @@ class HelpQueue {
                   )
               ]);
         const queue = new HelpQueue(queueChannel, queueExtensions, display, backupData);
-       
+
         await Promise.all([
             queueChannel.textChannel.permissionOverwrites.create(everyoneRole, {
                 SendMessages: false,
@@ -217,7 +217,7 @@ class HelpQueue {
         if (queue.timeUntilAutoClear !== 'AUTO_CLEAR_DISABLED') {
             await queue.startAutoClearTimer();
         }
-       
+
         // Emit events after queue is done creating
         await Promise.all(
             queueExtensions.map(extension => extension.onQueueCreate(queue))
@@ -262,7 +262,7 @@ class HelpQueue {
 
         this._activeHelperIds.delete(helperMember.id);
         this._pausedHelperIds.delete(helperMember.id);
-        
+
         if (this.getQueueState() === 'closed') {
             await this.startAutoClearTimer();
         }
@@ -560,7 +560,7 @@ class HelpQueue {
             ...this.queueExtensions.map(extension => extension.onQueueOpen(this)),
             this.triggerRender()
         ]);
-       
+
         if (!notify) {
             return;
         }
@@ -735,7 +735,7 @@ class HelpQueue {
                     this._timeUntilAutoClear.minutes * 1000 * 60
             )
         );
-        
+
         await this.triggerRender();
     }
 }

--- a/src/help-queue/help-queue.ts
+++ b/src/help-queue/help-queue.ts
@@ -681,7 +681,13 @@ class HelpQueue {
     }
 
     async updateQueueChannel(newChannel: QueueChannel): Promise<void> {
+        const oldChannel = this.queueChannel;
         this._queueChannel = newChannel;
+        await Promise.all(
+            this.queueExtensions.map(extension =>
+                extension.onQueueChannelUpdate(this, oldChannel, newChannel)
+            )
+        );
         await this.triggerRender();
     }
 

--- a/src/help-queue/help-queue.ts
+++ b/src/help-queue/help-queue.ts
@@ -1,6 +1,6 @@
 /** @module HelpQueueV2 */
 import type { GuildMember, TextChannel, Snowflake, PartialGuildMember } from 'discord.js';
-import type { QueueChannel } from '../attending-server/base-attending-server.js';
+import type { QueueChannel } from '../models/queue-channel.js';
 import type { QueueExtension } from '../extensions/extension-interface.js';
 import type { QueueBackup } from '../models/backups.js';
 import type { Helpee } from '../models/member-states.js';
@@ -110,7 +110,7 @@ class HelpQueue {
 
         for (const studentBackup of backupData.studentsInQueue) {
             // forEach backup, if there's a corresponding channel member, push it into queue
-            const correspondingMember = this.queueChannel.channelObj.members.get(
+            const correspondingMember = this.queueChannel.textChannel.members.get(
                 studentBackup.memberId
             );
             if (correspondingMember !== undefined) {
@@ -135,8 +135,8 @@ class HelpQueue {
     }
 
     /** #queue text channel object */
-    get channelObject(): Readonly<TextChannel> {
-        return this.queueChannel.channelObj;
+    get textChannelect(): Readonly<TextChannel> {
+        return this.queueChannel.textChannel;
     }
 
     /** First student; undefined if no one is here */
@@ -191,7 +191,7 @@ class HelpQueue {
             seriousModeEnabled: boolean;
         }
     ): Promise<HelpQueue> {
-        const everyoneRole = queueChannel.channelObj.guild.roles.everyone;
+        const everyoneRole = queueChannel.textChannel.guild.roles.everyone;
         const display = new QueueDisplay(queueChannel);
         const queueExtensions: QueueExtension[] = environment.disableExtensions
             ? []
@@ -205,7 +205,7 @@ class HelpQueue {
         const queue = new HelpQueue(queueChannel, queueExtensions, display, backupData);
        
         await Promise.all([
-            queueChannel.channelObj.permissionOverwrites.create(everyoneRole, {
+            queueChannel.textChannel.permissionOverwrites.create(everyoneRole, {
                 SendMessages: false,
                 CreatePrivateThreads: false,
                 CreatePublicThreads: false,
@@ -525,7 +525,7 @@ class HelpQueue {
         await Promise.all(
             [...this.activeHelperIds].map(
                 helperId =>
-                    this.queueChannel.channelObj.members
+                    this.queueChannel.textChannel.members
                         .get(helperId)
                         ?.send(embed)
                         .catch(() => {

--- a/src/help-queue/queue-display.ts
+++ b/src/help-queue/queue-display.ts
@@ -61,8 +61,7 @@ class QueueDisplay {
      * - binds the render index with a specific message
      * - if the message doesn't exist, send and re-bind. Avoids the unknown message issue
      */
-    private renderIndexMessageIdMap: Collection<RenderIndex, MessageId> =
-        new Collection();
+    private renderIndexMessageIdMap = new Collection<RenderIndex, MessageId>();
 
     /**
      * The mutex that locks the render method during render
@@ -76,8 +75,7 @@ class QueueDisplay {
      * - queue has render index 0
      * - immediately updated in both requestQueueRender and requestNonQueueEmbedRender
      */
-    private queueChannelEmbeds: Collection<RenderIndex, QueueChannelEmbed> =
-        new Collection();
+    private queueChannelEmbeds = new Collection<RenderIndex, QueueChannelEmbed>();
 
     /**
      * Whether the display has temporarily paused rendering

--- a/src/help-queue/queue-display.ts
+++ b/src/help-queue/queue-display.ts
@@ -1,7 +1,7 @@
 /** @module HelpQueueV2 */
 import { AsciiTable3, AlignmentEnum } from 'ascii-table3';
 import { QueueState, QueueViewModel } from './help-queue.js';
-import { QueueChannel } from '../attending-server/base-attending-server.js';
+import { QueueChannel } from '../models/queue-channel.js';
 import {
     Collection,
     ActionRowBuilder,
@@ -161,7 +161,7 @@ class QueueDisplay {
      * @param viewModel
      */
     requestQueueEmbedRender(viewModel: QueueViewModel): void {
-        const guildId = this.queueChannel.channelObj.guild.id;
+        const guildId = this.queueChannel.textChannel.guild.id;
         const embedTableMsg = new EmbedBuilder();
         embedTableMsg
             .setTitle(
@@ -305,8 +305,8 @@ class QueueDisplay {
      */
     private async render(force = false): Promise<void> {
         this.isRendering = true;
-        const queueChannelExists = this.queueChannel.channelObj.guild.channels.cache.has(
-            this.queueChannel.channelObj.id
+        const queueChannelExists = this.queueChannel.textChannel.guild.channels.cache.has(
+            this.queueChannel.textChannel.id
         );
         if (!queueChannelExists) {
             // temporary fix, do nothing if #queue doesn't exist
@@ -314,7 +314,7 @@ class QueueDisplay {
             return;
         }
         // this avoids the ephemeral reply being counted as a 'message'
-        const allMessages = await this.queueChannel.channelObj.messages.fetch({
+        const allMessages = await this.queueChannel.textChannel.messages.fetch({
             cache: false
         });
         // from all messages select message whose id exists in embedMessageIdMap
@@ -326,7 +326,7 @@ class QueueDisplay {
             existingEmbeds.size === this.queueChannelEmbeds.size &&
             allMessages.size === this.queueChannelEmbeds.size;
         if (!safeToEdit || force) {
-            const allMessages = await this.queueChannel.channelObj.messages.fetch();
+            const allMessages = await this.queueChannel.textChannel.messages.fetch();
             await Promise.all(allMessages.map(msg => msg.delete()));
             // sort by render index
             const sortedEmbeds = this.queueChannelEmbeds.sort(
@@ -334,7 +334,7 @@ class QueueDisplay {
             );
             // Cannot promise all here, contents need to be sent in order
             for (const embed of sortedEmbeds.values()) {
-                const newEmbedMessage = await this.queueChannel.channelObj.send({
+                const newEmbedMessage = await this.queueChannel.textChannel.send({
                     ...embed.contents,
                     flags: MessageFlags.SuppressNotifications
                 });
@@ -358,7 +358,7 @@ class QueueDisplay {
     private getVcStatus(helperId: Snowflake): string {
         const spacer = '\u3000'; // ideographic space character, extra wide
         const voiceChannel =
-            this.queueChannel.channelObj.guild.voiceStates.cache.get(helperId)?.channel;
+            this.queueChannel.textChannel.guild.voiceStates.cache.get(helperId)?.channel;
         // using # gives the same effect as if we use the id
         // bc students can't see the channel ping if they don't have permission
         const vcStatus = voiceChannel

--- a/src/interaction-handling/command-handler.ts
+++ b/src/interaction-handling/command-handler.ts
@@ -308,9 +308,8 @@ async function clearAll(
         CommandNames.clear_all,
         'botAdmin'
     );
-    const allQueues = await server.getQueueChannels();
 
-    if (allQueues.length === 0) {
+    if (server.queues.length === 0) {
         throw ExpectedParseErrors.serverHasNoQueue;
     }
 
@@ -332,7 +331,6 @@ async function listHelpers(
         return;
     }
 
-    const allQueues = await server.getQueueChannels();
     const table = new AsciiTable3()
         .setHeading(
             'Tutor name',
@@ -354,8 +352,9 @@ async function listHelpers(
                 helper.member.roles.cache
                     .filter(
                         role =>
-                            allQueues.find(queue => queue.queueName === role.name) !==
-                            undefined
+                            server.queueChannels.find(
+                                queue => queue.queueName === role.name
+                            ) !== undefined
                     )
                     .map(role => role.name)
                     .toString(), // Available Queues
@@ -448,10 +447,8 @@ async function cleanupAllQueues(
         CommandNames.cleanup_all,
         'botAdmin'
     );
-
-    const allQueues = await server.getQueueChannels();
     await Promise.all(
-        allQueues.map(queueChannel =>
+        server.queueChannels.map(queueChannel =>
             server.getQueueById(queueChannel.parentCategoryId).triggerForceRender()
         )
     );

--- a/src/interaction-handling/shared-validations.ts
+++ b/src/interaction-handling/shared-validations.ts
@@ -7,10 +7,8 @@ import {
     PermissionsBitField,
     StringSelectMenuInteraction
 } from 'discord.js';
-import {
-    AttendingServer,
-    QueueChannel
-} from '../attending-server/base-attending-server.js';
+import { AttendingServer } from '../attending-server/base-attending-server.js';
+import { QueueChannel } from '../models/queue-channel.js';
 import {
     isCategoryChannel,
     isQueueTextChannel,
@@ -136,7 +134,7 @@ function hasValidQueueArgument(
         throw ExpectedParseErrors.noQueueTextChannel(parentCategory.name);
     }
     const queueChannel: QueueChannel = {
-        channelObj: queueTextChannel,
+        textChannel: queueTextChannel,
         queueName: parentCategory.name,
         parentCategoryId: parentCategory.id
     };

--- a/src/models/queue-channel.ts
+++ b/src/models/queue-channel.ts
@@ -6,8 +6,11 @@ import { CategoryChannelId } from '../utils/type-aliases.js';
  * - Guarantees that a queueName and parentCategoryId exists
  */
 type QueueChannel = Readonly<{
+    /** The discord text channel named "queue" */
     textChannel: TextChannel;
+    /** Name of the queue, matches the parent category name */
     queueName: string;
+    /** Parent category channel id */
     parentCategoryId: CategoryChannelId;
 }>;
 

--- a/src/models/queue-channel.ts
+++ b/src/models/queue-channel.ts
@@ -1,0 +1,14 @@
+import { TextChannel } from 'discord.js';
+import { CategoryChannelId } from '../utils/type-aliases.js';
+
+/**
+ * Wrapper for TextChannel
+ * - Guarantees that a queueName and parentCategoryId exists
+ */
+type QueueChannel = Readonly<{
+    textChannel: TextChannel;
+    queueName: string;
+    parentCategoryId: CategoryChannelId;
+}>;
+
+export { QueueChannel };

--- a/src/utils/util-functions.ts
+++ b/src/utils/util-functions.ts
@@ -126,10 +126,11 @@ function addTimeOffset(date: Date, hours: number, minutes: number): Date {
  * @returns list of queue roles
  */
 async function getQueueRoles(server: FrozenServer, member: GuildMember): Promise<Role[]> {
-    const queueChannels = await server.getQueueChannels();
     return [
         ...member.roles.cache
-            .filter(role => queueChannels.some(queue => queue.queueName === role.name))
+            .filter(role =>
+                server.queueChannels.some(queue => queue.queueName === role.name)
+            )
             .values()
     ];
 }


### PR DESCRIPTION
(sorry for the rather big PR)
1. removed `queueChannelsCache`
2. renamed `channelObj` to `textChannel` in `QueueChannel` type
3. moved `onQueueUpdate` to `QueueExtension`
4. moved variables referenced by all queues in the same server to a static collection